### PR TITLE
[MOB-827] SectionLabel button, non-button 영역 분리 및 textColor 스펙 추가

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -21,6 +22,7 @@ fun SectionLabel(
         text: String,
         modifier: Modifier = Modifier,
         painter: Painter? = null,
+        textColor: Color = BezierTheme.colors.txtBlackDark,
         leftContents: (@Composable RowScope.() -> Unit)? = null,
         nonButtonContents: (@Composable RowScope.() -> Unit)? = null,
         buttonContents: (@Composable RowScope.() -> Unit)? = null,
@@ -63,7 +65,7 @@ fun SectionLabel(
                         maxLines = 1,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Bold,
-                        color = BezierTheme.colors.txtBlackDark,
+                        color = textColor,
                 )
 
                 if (leftContents != null) {
@@ -98,9 +100,16 @@ fun SectionLabel(
 @Preview(showBackground = true)
 @Composable
 fun SectionLabelTextPreview() {
-    SectionLabel(
-            text = "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.",
-    )
+    Column {
+        SectionLabel(
+                text = "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.",
+        )
+        SectionLabel(
+                text = "It is a txtBlackDarkest color text",
+                textColor = BezierTheme.colors.txtBlackDarkest,
+        )
+    }
+
 }
 
 @Preview(showBackground = true)

--- a/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
@@ -1,7 +1,17 @@
 package io.channel.bezier.component
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment

--- a/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
@@ -1,14 +1,7 @@
 package io.channel.bezier.component
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.material.Icon
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -29,7 +22,8 @@ fun SectionLabel(
         modifier: Modifier = Modifier,
         painter: Painter? = null,
         leftContents: (@Composable RowScope.() -> Unit)? = null,
-        rightContents: (@Composable RowScope.() -> Unit)? = null,
+        nonButtonContents: (@Composable RowScope.() -> Unit)? = null,
+        buttonContents: (@Composable RowScope.() -> Unit)? = null,
 ) {
     Row(
             modifier = modifier
@@ -51,8 +45,8 @@ fun SectionLabel(
             if (painter != null) {
                 Icon(
                         modifier = Modifier
-                                .padding(end = 8.dp)
-                                .size(20.dp),
+                                .padding(end = 12.dp)
+                                .size(24.dp),
                         painter = painter,
                         tint = BezierTheme.colors.txtBlackDark,
                         contentDescription = null,
@@ -78,15 +72,23 @@ fun SectionLabel(
             }
         }
 
-        if (rightContents != null) {
-            CompositionLocalProvider(LocalContentColor provides BezierTheme.colors.txtBlackDark) {
+        CompositionLocalProvider(LocalContentColor provides BezierTheme.colors.txtBlackDark) {
+            if (nonButtonContents != null) {
                 Row(
-                        modifier = Modifier
-                                .padding(vertical = 1.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    nonButtonContents()
+                }
+                Spacer(modifier = Modifier.width(6.dp))
+            }
+
+            if (buttonContents != null) {
+                Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    rightContents()
+                    buttonContents()
                 }
             }
         }
@@ -116,34 +118,36 @@ fun SectionLabelWithRightContentsPreview() {
     SectionLabel(
             painter = painterResource(R.drawable.icon_person),
             text = "The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.",
-    ) {
-        Icon(
-                modifier = Modifier
-                        .padding(end = 10.dp)
-                        .size(20.dp),
-                painter = painterResource(R.drawable.icon_lock),
-                tint = BezierTheme.colors.txtBlackDark,
-                contentDescription = null,
-        )
+            nonButtonContents = {
+                Icon(
+                        modifier = Modifier
+                                .padding(end = 10.dp)
+                                .size(20.dp),
+                        painter = painterResource(R.drawable.icon_lock),
+                        tint = BezierTheme.colors.txtBlackDark,
+                        contentDescription = null,
+                )
+            },
+            buttonContents = {
+                Icon(
+                        modifier = Modifier
+                                .padding(end = 10.dp)
+                                .size(20.dp),
+                        painter = painterResource(R.drawable.icon_hyphen_bold),
+                        tint = BezierTheme.colors.txtBlackDark,
+                        contentDescription = null,
+                )
 
-        Icon(
-                modifier = Modifier
-                        .padding(end = 10.dp)
-                        .size(20.dp),
-                painter = painterResource(R.drawable.icon_hyphen_bold),
-                tint = BezierTheme.colors.txtBlackDark,
-                contentDescription = null,
-        )
-
-        Icon(
-                modifier = Modifier
-                        .padding(end = 5.dp)
-                        .size(20.dp),
-                painter = painterResource(R.drawable.icon_cancel),
-                tint = BezierTheme.colors.txtBlackDark,
-                contentDescription = null,
-        )
-    }
+                Icon(
+                        modifier = Modifier
+                                .padding(end = 5.dp)
+                                .size(20.dp),
+                        painter = painterResource(R.drawable.icon_cancel),
+                        tint = BezierTheme.colors.txtBlackDark,
+                        contentDescription = null,
+                )
+            },
+    )
 }
 
 @Preview(showBackground = true)
@@ -162,9 +166,9 @@ fun SectionLabelWithLeftContentsPreview() {
     )
 }
 
-@Preview(showBackground = true)
 @Composable
-fun SectionLabelWithAllContentsPreview() {
+@Preview(showBackground = true)
+private fun SectionLabelWithAllContentsPreview() {
     SectionLabel(
             painter = painterResource(R.drawable.icon_person),
             text = "The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested.",
@@ -176,33 +180,25 @@ fun SectionLabelWithAllContentsPreview() {
                         size = Badge.Size.S,
                 )
             },
-    ) {
-        Icon(
-                modifier = Modifier
-                        .padding(5.dp)
-                        .size(20.dp),
-                painter = painterResource(R.drawable.icon_lock),
-                tint = BezierTheme.colors.txtBlackDark,
-                contentDescription = null,
-        )
-
-        Icon(
-                modifier = Modifier
-                        .padding(5.dp)
-                        .size(20.dp),
-                painter = painterResource(R.drawable.icon_hyphen_bold),
-                tint = BezierTheme.colors.txtBlackDark,
-                contentDescription = null,
-        )
-
-        Icon(
-                modifier = Modifier
-                        .padding(5.dp)
-                        .size(20.dp),
-                painter = painterResource(R.drawable.icon_cancel),
-                tint = BezierTheme.colors.txtBlackDark,
-                contentDescription = null,
-        )
-    }
+            nonButtonContents = {
+                Icon(
+                        modifier = Modifier
+                                .padding(5.dp)
+                                .size(20.dp),
+                        painter = painterResource(R.drawable.icon_lock),
+                        tint = BezierTheme.colors.txtBlackDark,
+                        contentDescription = null,
+                )
+            },
+            buttonContents = {
+                Icon(
+                        modifier = Modifier
+                                .padding(5.dp)
+                                .size(20.dp),
+                        painter = painterResource(R.drawable.icon_cancel),
+                        tint = BezierTheme.colors.txtBlackDark,
+                        contentDescription = null,
+                )
+            },
+    )
 }
-


### PR DESCRIPTION
- 기존 SectionLabel rightContents가 button, non-button 영역으로 분리되었습니다
  - ListItemContainer와 비슷한 스펙이지만, SectionLabel에선 두가지 영역을 동시에 사용할 수 있습니다.
- 아이콘 크기가 24로 커졌습니다. 기존 ListItemContainer와 동일한 사이즈로 정렬을 맞추기 위함입니다
- textColor 스펙이 추가되었습니다

|as-is|to-be (with non-button contents)|
|-|-|
|<img width="622" alt="image" src="https://github.com/channel-io/bezier-compose/assets/36754680/79f5b629-1a0a-43ea-8fb9-2ccf625579f2">|<img width="622" alt="image" src="https://github.com/channel-io/bezier-compose/assets/36754680/bb9b3ed2-f3ac-491f-a8a7-47ec5b26122e">|

### 관련 링크
[베지어 쓰레드](https://desk.channel.io/#/channels/1/team_chats/groups/62019/661f907921b4e119655e)
[관련 쓰레드](https://desk.channel.io/#/channels/1/team_chats/groups/147372/663ca66b4309d19daf0b)
[피그마 링크](https://www.figma.com/design/XW4RS4pqo2Kne0vfKydLSE/%ED%8C%80%EC%B1%97-%EC%84%B9%EC%85%98%ED%99%94?node-id=2001-232420&t=gE8fhYuYVqoGEU3j-4)


