### PR TITLE
[MOB-1659] OutlineBorder 추가

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/extension/ModifierExtensions.kt
+++ b/bezier/src/main/java/io/channel/bezier/extension/ModifierExtensions.kt
@@ -13,9 +13,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -27,6 +34,31 @@ internal inline fun Modifier.thenIf(
     this.then(block(Modifier))
 } else {
     this
+}
+
+internal fun Modifier.outlineBorder(
+        width: Dp,
+        color: Color,
+        shape: Shape = RectangleShape,
+): Modifier = this.drawBehind {
+    val widthPx = width.toPx()
+
+    val outline = shape.createOutline(
+            Size(size.width + widthPx, size.height + widthPx),
+            layoutDirection,
+            this,
+    )
+
+    translate(
+            left = -widthPx / 2,
+            top = -widthPx / 2,
+    ) {
+        drawOutline(
+                outline = outline,
+                color = color,
+                style = Stroke(widthPx),
+        )
+    }
 }
 
 fun Modifier.roundedBackground(

--- a/bezier/src/main/java/io/channel/bezier/extension/ModifierExtensions.kt
+++ b/bezier/src/main/java/io/channel/bezier/extension/ModifierExtensions.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -41,22 +42,27 @@ internal fun Modifier.outlineBorder(
         color: Color,
         shape: Shape = RectangleShape,
 ): Modifier = this.drawBehind {
+    /**
+     * 테두리와 컨텐츠 사이에 약간의 공간이 남는 현상을 방지하기 위해서
+     * 안쪽으로 1px 만큼 테두리를 표시합니다.
+     */
+    val adjustmentValue = 1
     val widthPx = width.toPx()
 
     val outline = shape.createOutline(
-            Size(size.width + widthPx, size.height + widthPx),
+            Size(size.width + widthPx - adjustmentValue, size.height + widthPx - adjustmentValue),
             layoutDirection,
             this,
     )
 
     translate(
-            left = -widthPx / 2,
-            top = -widthPx / 2,
+            left = -(widthPx - adjustmentValue) / 2,
+            top = -(widthPx - adjustmentValue) / 2,
     ) {
         drawOutline(
                 outline = outline,
                 color = color,
-                style = Stroke(widthPx),
+                style = Stroke(widthPx + adjustmentValue),
         )
     }
 }


### PR DESCRIPTION
영역을 차지하지 않는 테두리를 그리는 OutlineBorder 함수를 추가했습니다.

파란 배경이 컴포넌트의 영역이고 테두리는 컴포넌트 영역 바깥으로 그려집니다.

![image](https://github.com/user-attachments/assets/96ff407d-728c-45aa-88a7-7269ab7eb4ce)
