### PR TITLE
[MOB-1718] 버튼 maxline 제거

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/compose/component/button/BezierButton.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/button/BezierButton.kt
@@ -91,7 +91,6 @@ fun BezierButton(
                     text = text,
                     style = size.textStyle(),
                     color = contentColor,
-                    overflow = TextOverflow.Ellipsis,
             )
 
             if (suffixContent != null) {

--- a/bezier/src/main/java/io/channel/bezier/compose/component/button/BezierButton.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/button/BezierButton.kt
@@ -91,7 +91,6 @@ fun BezierButton(
                     text = text,
                     style = size.textStyle(),
                     color = contentColor,
-                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
             )
 


### PR DESCRIPTION

스레드 링크: https://desk.channel.io/root/threads/groups/(CT)BezierRedesign-244958/66ab3ca74081ce013f0e/66ab3ca74081ce013f0e
스펙문서: https://www.notion.so/channelio/Button-95e7964c1e174aaa9923abc8ecc193b3

스레드 스샷
<img width="292" alt="image" src="https://github.com/user-attachments/assets/b60dc5f7-7ce0-4b44-ab78-2e701691dc41">


그냥 꽉 찬상태는 기존과 동일합니다.
<img width="413" alt="image" src="https://github.com/user-attachments/assets/0f082cb6-399e-4001-86da-7fc9cd821467">

as-is
<img width="415" alt="image" src="https://github.com/user-attachments/assets/e9e89201-b422-43d3-9719-cf460e6e3c39">

to-be
<img width="418" alt="image" src="https://github.com/user-attachments/assets/eb95519e-1953-42d3-8ced-55e4e4336ba5">
