### PR TITLE
[MOB-1758] Loader Size 추가

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/compose/component/loader/BezierLoader.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/loader/BezierLoader.kt
@@ -16,6 +16,8 @@ import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.component.loader.properties.BezierLoaderSize
 import io.channel.bezier.compose.component.loader.properties.BezierLoaderVariant
 
+private const val StrokeWidthRatio = 0.12f
+
 @Composable
 fun BezierLoader(
         variant: BezierLoaderVariant,
@@ -24,7 +26,7 @@ fun BezierLoader(
     CircularProgressIndicator(
             modifier = Modifier.size(size.size),
             color = variant.foregroundColor().color,
-            strokeWidth = size.strokeWidth,
+            strokeWidth = size.size * StrokeWidthRatio,
             backgroundColor = variant.backgroundColor().color,
             strokeCap = StrokeCap.Round,
     )

--- a/bezier/src/main/java/io/channel/bezier/compose/component/loader/properties/BezierLoaderSize.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/loader/properties/BezierLoaderSize.kt
@@ -5,14 +5,20 @@ import androidx.compose.ui.unit.dp
 
 enum class BezierLoaderSize(
         internal val size: Dp,
-        internal val strokeWidth: Dp,
 ) {
+    XXSmall(
+            size = 16.dp,
+    ),
+    XSmall(
+            size = 20.dp,
+    ),
     Small(
-            size = 28.dp,
-            strokeWidth = 4.dp,
+            size = 24.dp,
     ),
     Medium(
+            size = 28.dp,
+    ),
+    Large(
             size = 50.dp,
-            strokeWidth = 6.dp,
     ),
 }


### PR DESCRIPTION
Loader의 사이즈를 추가합니다.

StorkeWidth의 값이 상수에서 계산하는 방식으로 변경됩니다.

<img width="375" alt="image" src="https://github.com/user-attachments/assets/3f618cc7-f9d0-4e54-af24-93d936d17612">

피그마: https://www.figma.com/design/KyhPPZeeC0JBmTclJGe3nn/Status?node-id=74-1001&t=3x6k4S3dNVzQVYta-4