### PR TITLE
[MOB-2057] Compose BOM 2024.09.02 변경

### DIFF
--- a/bezier/build.gradle.kts
+++ b/bezier/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.ui.graphics)
     implementation(libs.ui.tooling.preview)
     implementation(libs.material)
+    implementation(libs.material.icons)
     implementation(libs.coil)
     implementation(libs.coil.gif)
 

--- a/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
+++ b/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
@@ -1,11 +1,12 @@
 package io.channel.bezier
 
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.LocalContentColor
-import androidx.compose.material.ripple.LocalRippleTheme
-import androidx.compose.material.ripple.RippleAlpha
-import androidx.compose.material.ripple.RippleTheme
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.LocalRippleConfiguration
+import androidx.compose.material.RippleConfiguration
+import androidx.compose.material.RippleDefaults
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
@@ -15,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import io.channel.bezier.color.Colors
 import io.channel.bezier.color.darkColors
 import io.channel.bezier.color.lightColors
@@ -24,6 +26,7 @@ import io.channel.bezier.compose.color_v2.darkFunctionalTokens
 import io.channel.bezier.compose.color_v2.lightFunctionalTokens
 import io.channel.bezier.compose.typography.Typography
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun BezierTheme(
         isDark: Boolean = BezierTheme.isDark,
@@ -50,12 +53,22 @@ fun BezierTheme(
 
     val colorSchemes = ColorSchemes(functionalColorsV2, semanticTokens)
 
+    val contentColor = LocalContentColor.current
+    val rippleConfiguration = RippleConfiguration(
+            color = if (isDark && contentColor.luminance() < 0.5) {
+                Color.White
+            } else {
+                contentColor
+            },
+            rippleAlpha = RippleDefaults.rippleAlpha(contentColor, !isDark),
+    )
+
 
     CompositionLocalProvider(
             LocalColors provides colors,
             LocalColorsV2 provides colorSchemes,
-            LocalIndication provides rememberRipple(),
-            LocalRippleTheme provides BezierRippleTheme,
+            LocalIndication provides ripple(),
+            LocalRippleConfiguration provides rippleConfiguration,
             LocalTypography provides typography,
     ) {
         content()
@@ -86,17 +99,3 @@ internal val LocalColors = staticCompositionLocalOf { lightColors() }
 
 internal val LocalColorsV2 = staticCompositionLocalOf<ColorSchemes> { throw UnsupportedOperationException() }
 internal val LocalTypography = staticCompositionLocalOf { Typography() }
-
-private object BezierRippleTheme : RippleTheme {
-    @Composable
-    override fun defaultColor(): Color = RippleTheme.defaultRippleColor(
-            contentColor = LocalContentColor.current,
-            lightTheme = !BezierTheme.isDark,
-    )
-
-    @Composable
-    override fun rippleAlpha(): RippleAlpha = RippleTheme.defaultRippleAlpha(
-            contentColor = LocalContentColor.current,
-            lightTheme = !BezierTheme.isDark,
-    )
-}

--- a/bezier/src/main/java/io/channel/bezier/component/Checkbox.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Checkbox.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ripple
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -197,7 +197,7 @@ fun Checkbox(
                         .background(color.backgroundColor(type, state))
                         .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
-                                indication = rememberRipple(),
+                                indication = ripple(),
                                 enabled = enabled,
                         ) {
                             onStateChange(state.toggle())

--- a/bezier/src/main/java/io/channel/bezier/component/OutlineItem.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/OutlineItem.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -45,7 +45,7 @@ fun OutlineItem(
                 modifier = Modifier
                         .clickable(
                                 enabled = onClickExpand != null && toggle != OutlineToggle.Leaf,
-                                indication = rememberRipple(radius = 12.dp),
+                                indication = ripple(radius = 12.dp),
                                 interactionSource = remember { MutableInteractionSource() },
                                 onClick = { onClickExpand?.invoke() },
                         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
 lifecycle-runtime-ktx = "2.6.1"
 activity-compose = "1.7.0"
-compose-bom = "2023.08.00"
+compose-bom = "2024.09.02"
 compose-compiler = "1.5.1"
 coil = "2.4.0"
 
@@ -26,6 +26,7 @@ ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 material = { group = "androidx.compose.material", name = "material" }
+material-icons = { group = "androidx.compose.material", name = "material-icons-core" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
 


### PR DESCRIPTION
`AnchoredDraggableState` 사용을 위해 버전업 할 겸 Bom 버전을 최신으로 업데이트합니다.

- Icons 클래스가 기존 의존성에서 분리되어 별도로 추가해주었습니다.
- Ripple이 클릭 관련 최적화가 적용되어 API 스펙이 변경되었는데 이를 반영했습니다.
https://developer.android.com/develop/ui/compose/touch-input/user-interactions/migrate-indication-ripple?hl=ko#migrate-remember-ripple