### PR TITLE
[MOB-2068] Switch 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/BezierSwitch.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/BezierSwitch.kt
@@ -1,0 +1,84 @@
+package io.channel.bezier.compose.component.switch
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.compose.component.switch.source.BezierSwitchControl
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+
+@Composable
+fun BezierSwitch(
+        text: String,
+        checked: Boolean,
+        onCheckedChange: (Boolean) -> Unit,
+        modifier: Modifier = Modifier,
+) {
+    var currentState by remember(checked) {
+        mutableStateOf(checked)
+    }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { currentState }
+                .debounce(1000L)
+                .filter { currentState != checked }
+                .collectLatest {
+                    currentState = checked
+                }
+    }
+
+    Row(
+            modifier = modifier.clickable {
+                currentState = !currentState
+            },
+            verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+                modifier = Modifier.weight(1f),
+                text = text,
+                style = BezierTheme.typography.caption1Regular,
+                color = BezierTheme.colorSchemes.fgBlackDarkest.color,
+        )
+        BezierSwitchControl(
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                checked = currentState,
+                onCheckedChange = { newValue ->
+                    onCheckedChange(newValue)
+                },
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun BezierSwitchPreview() {
+    var checked by remember {
+        mutableStateOf(false)
+    }
+
+    BezierTheme {
+        BezierSwitch(
+                modifier = Modifier.padding(16.dp),
+                text = "hello~",
+                checked = checked,
+                onCheckedChange = {},
+        )
+    }
+}

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/BezierSwitch.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/BezierSwitch.kt
@@ -52,7 +52,7 @@ fun BezierSwitch(
                         currentOnCheckedChange(newValue)
                     }
                 }
-                .debounce(1000L)
+                .debounce(10000L)
                 .filter { it != currentChecked }
                 .collect {
                     state.forceAnimationCheck = !state.forceAnimationCheck

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/BezierSwitch.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/BezierSwitch.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -38,13 +37,11 @@ fun BezierSwitch(
     val coroutineScope = rememberCoroutineScope()
 
     val switchControlState = rememberBezierSwitchControlState(checked)
-    val currentOnCheckedChange by rememberUpdatedState(onCheckedChange)
 
     LaunchedEffect(switchControlState.anchoredDraggableState) {
         snapshotFlow { switchControlState.anchoredDraggableState.currentValue }
                 .collect { newValue ->
                     if (newValue == switchControlState.checked) {
-                        currentOnCheckedChange(newValue)
                         return@collect
                     }
 

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
@@ -1,0 +1,175 @@
+package io.channel.bezier.compose.component.switch.source
+
+import androidx.compose.animation.core.TweenSpec
+import androidx.compose.animation.core.exponentialDecay
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.compose.foundation.ShadowStyle
+import io.channel.bezier.compose.foundation.bezierShadow
+import kotlinx.coroutines.flow.collectLatest
+
+private val SwitchWidth = 44.dp
+private val SwitchPadding = 3.dp
+private val ThumbSize = 22.dp
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun BezierSwitchControl(
+        checked: Boolean,
+        onCheckedChange: (Boolean) -> Unit,
+        modifier: Modifier = Modifier,
+) {
+    /**
+     * 스위치에서 Thumb가 그려질 수 있는 너비는 양 옆 패딩을 제외한 38입니다.
+     * Thumb은 중앙 점을 기준으로 그리므로 22의 절반인 11에서 그리면 시작 점이 됩니다.
+     * 끝 점은 마찬가지로 끝에서 11만큼 멀어져야 하므로 38 - 11 = 27 에서 그려져야합니다.
+     * Thumb은 그려질 때 11을 항상 더하므로 계산식에서는 ThumbSize를 빼줍니다.
+     * 결과적으로 maxBound는 16이 되며 11을 더해서 27이 되었을 때 스위치 끝에 그려지게 됩니다.
+     */
+    val maxBound = SwitchWidth - SwitchPadding * 2 - ThumbSize
+    val maxBoundPx = with(LocalDensity.current) { maxBound.toPx() }
+
+    val switchVelocityThresholdPx = with(LocalDensity.current) { 10.dp.toPx() }
+
+    val anchoredDraggableState = remember {
+        AnchoredDraggableState(
+                initialValue = checked,
+                snapAnimationSpec = TweenSpec(durationMillis = 100),
+                decayAnimationSpec = exponentialDecay(),
+                anchors = DraggableAnchors {
+                    false at 0f
+                    true at maxBoundPx
+                },
+                positionalThreshold = { totalDistance -> totalDistance * 0.7f },
+                velocityThreshold = { switchVelocityThresholdPx },
+        )
+    }
+
+    val currentOnCheckedChange by rememberUpdatedState(onCheckedChange)
+    val currentChecked by rememberUpdatedState(checked)
+
+    LaunchedEffect(anchoredDraggableState) {
+        snapshotFlow { anchoredDraggableState.currentValue }
+                .collectLatest { newValue ->
+                    if (currentChecked != newValue) {
+                        currentOnCheckedChange(newValue)
+                    }
+                }
+    }
+
+    LaunchedEffect(checked) {
+        if (checked != anchoredDraggableState.currentValue) {
+            anchoredDraggableState.animateTo(checked)
+        }
+    }
+
+
+
+    Box(
+            modifier = modifier
+                    .clip(CircleShape)
+                    .requiredSize(width = SwitchWidth, height = 28.dp)
+                    .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { onCheckedChange(!checked) },
+                    ),
+    ) {
+        Track(fraction = { anchoredDraggableState.requireOffset().dp / SwitchWidth })
+        Box(
+                modifier = Modifier
+                        .padding(SwitchPadding)
+                        .anchoredDraggable(
+                                state = anchoredDraggableState,
+                                orientation = Orientation.Horizontal,
+                        ),
+        ) {
+            Thumb(thumbValue = { anchoredDraggableState.requireOffset() })
+        }
+    }
+}
+
+@Composable
+private fun Track(fraction: () -> Float) {
+    val start = BezierTheme.colorSchemes.bgBlackDark.color
+    val stop = BezierTheme.colorSchemes.bgGreenNormal.color
+
+    Canvas(
+            modifier = Modifier
+                    .fillMaxSize(),
+    ) {
+        val backgroundColor = lerp(
+                start = start,
+                stop = stop,
+                fraction = fraction(),
+        )
+
+        drawRect(backgroundColor)
+    }
+}
+
+@Composable
+private fun Thumb(thumbValue: () -> Float) {
+    val color = BezierTheme.colorSchemes.fgAbsoluteWhiteDark.color
+
+    Canvas(
+            modifier = Modifier
+                    .size(ThumbSize)
+                    .bezierShadow(ShadowStyle.Shadow2, CircleShape),
+    ) {
+        drawLine(
+                color = color,
+                start = Offset(thumbValue() + (size.width / 2), this.center.y),
+                end = Offset(thumbValue() + (size.width / 2), this.center.y),
+                strokeWidth = size.width,
+                cap = StrokeCap.Round,
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun BezierSwitchControlPreview() {
+    var checked by remember {
+        mutableStateOf(false)
+    }
+
+    BezierTheme {
+        BezierSwitchControl(
+                checked = checked,
+                onCheckedChange = {
+                    checked = it
+                },
+        )
+    }
+}

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
@@ -76,16 +76,7 @@ internal fun BezierSwitchControl(
                     ),
     ) {
         Track(fraction = { anchoredDraggableState.requireOffset().dp / SwitchWidth })
-        Box(
-                modifier = Modifier
-                        .padding(SwitchPadding)
-                        .anchoredDraggable(
-                                state = anchoredDraggableState,
-                                orientation = Orientation.Horizontal,
-                        ),
-        ) {
-            Thumb(thumbValue = { anchoredDraggableState.requireOffset() })
-        }
+        Thumb(anchoredDraggableState = anchoredDraggableState)
     }
 }
 
@@ -112,22 +103,36 @@ private fun Track(fraction: () -> Float) {
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun Thumb(thumbValue: () -> Float) {
+private fun Thumb(
+        anchoredDraggableState: AnchoredDraggableState<Boolean>,
+) {
     val color = BezierTheme.colorSchemes.fgAbsoluteWhiteDark.color
 
-    Canvas(
+    Box(
             modifier = Modifier
-                    .size(ThumbSize)
-                    .bezierShadow(ShadowStyle.Shadow2, CircleShape),
+                    .padding(SwitchPadding)
+                    .anchoredDraggable(
+                            state = anchoredDraggableState,
+                            orientation = Orientation.Horizontal,
+                    ),
     ) {
-        drawLine(
-                color = color,
-                start = Offset(thumbValue() + (size.width / 2), this.center.y),
-                end = Offset(thumbValue() + (size.width / 2), this.center.y),
-                strokeWidth = size.width,
-                cap = StrokeCap.Round,
-        )
+        Canvas(
+                modifier = Modifier
+                        .size(ThumbSize)
+                        .bezierShadow(ShadowStyle.Shadow2, CircleShape),
+        ) {
+            val thumbValue = anchoredDraggableState.requireOffset()
+
+            drawLine(
+                    color = color,
+                    start = Offset(thumbValue + (size.width / 2), this.center.y),
+                    end = Offset(thumbValue + (size.width / 2), this.center.y),
+                    strokeWidth = size.width,
+                    cap = StrokeCap.Round,
+            )
+        }
     }
 }
 

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
@@ -105,9 +105,9 @@ internal fun BezierSwitchControl(
             anchoredDraggableState.animateTo(checked)
         }
     }
-
     Box(
             modifier = modifier
+                    .padding(2.dp)
                     .clip(CircleShape)
                     .requiredSize(width = SwitchWidth, height = 28.dp)
                     .clickable(

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
@@ -24,9 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -38,10 +36,6 @@ import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.foundation.ShadowStyle
 import io.channel.bezier.compose.foundation.bezierShadow
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 private val SwitchWidth = 44.dp
@@ -57,7 +51,7 @@ internal fun BezierSwitchControl(
 ) {
     val coroutineScope = rememberCoroutineScope()
 
-    val checked = state.initialChecked
+    val checked = state.checked
     val anchoredDraggableState = state.anchoredDraggableState
 
     LaunchedEffect(checked, state.forceAnimationCheck) {
@@ -157,9 +151,10 @@ private fun BezierSwitchControlPreview() {
 @OptIn(ExperimentalFoundationApi::class)
 @Stable
 internal class BezierSwitchControlState(
-        val initialChecked: Boolean,
+        initialChecked: Boolean,
         val anchoredDraggableState: AnchoredDraggableState<Boolean>,
 ) {
+    var checked by mutableStateOf(initialChecked)
     var forceAnimationCheck by mutableStateOf(false)
 
     suspend fun trySwitch(onCheckedChange: (Boolean) -> Unit) {
@@ -200,5 +195,7 @@ internal fun rememberBezierSwitchControlState(checked: Boolean): BezierSwitchCon
                         velocityThreshold = { switchVelocityThresholdPx },
                 ),
         )
+    }.apply {
+        this.checked = checked
     }
 }

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControl.kt
@@ -1,12 +1,9 @@
 package io.channel.bezier.compose.component.switch.source
 
-import androidx.compose.animation.core.TweenSpec
-import androidx.compose.animation.core.exponentialDecay
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
-import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.animateTo
@@ -19,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,7 +26,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
@@ -38,9 +33,9 @@ import io.channel.bezier.compose.foundation.ShadowStyle
 import io.channel.bezier.compose.foundation.bezierShadow
 import kotlinx.coroutines.launch
 
-private val SwitchWidth = 44.dp
-private val SwitchPadding = 3.dp
-private val ThumbSize = 22.dp
+internal val SwitchWidth = 44.dp
+internal val SwitchPadding = 3.dp
+internal val ThumbSize = 22.dp
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -150,57 +145,5 @@ private fun BezierSwitchControlPreview() {
                     checked = it
                 },
         )
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Stable
-internal class BezierSwitchControlState(
-        initialChecked: Boolean,
-        val anchoredDraggableState: AnchoredDraggableState<Boolean>,
-) {
-    var checked by mutableStateOf(initialChecked)
-    var forceAnimationCheck by mutableStateOf(false)
-
-    suspend fun trySwitch(onCheckedChange: (Boolean) -> Unit) {
-        if (!anchoredDraggableState.isAnimationRunning) {
-            onCheckedChange(!anchoredDraggableState.currentValue)
-            anchoredDraggableState.animateTo(!anchoredDraggableState.currentValue)
-        }
-    }
-}
-
-@Composable
-@OptIn(ExperimentalFoundationApi::class)
-internal fun rememberBezierSwitchControlState(checked: Boolean): BezierSwitchControlState {
-    /**
-     * 스위치에서 Thumb가 그려질 수 있는 너비는 양 옆 패딩을 제외한 38입니다.
-     * Thumb은 중앙 점을 기준으로 그리므로 22의 절반인 11에서 그리면 시작 점이 됩니다.
-     * 끝 점은 마찬가지로 끝에서 11만큼 멀어져야 하므로 38 - 11 = 27 에서 그려져야합니다.
-     * Thumb은 그려질 때 11을 항상 더하므로 계산식에서는 ThumbSize를 빼줍니다.
-     * 결과적으로 maxBound는 16이 되며 11을 더해서 27이 되었을 때 스위치 끝에 그려지게 됩니다.
-     */
-    val maxBound = SwitchWidth - SwitchPadding * 2 - ThumbSize
-    val maxBoundPx = with(LocalDensity.current) { maxBound.toPx() }
-
-    val switchVelocityThresholdPx = with(LocalDensity.current) { 10.dp.toPx() }
-
-    return remember {
-        BezierSwitchControlState(
-                initialChecked = checked,
-                anchoredDraggableState = AnchoredDraggableState(
-                        initialValue = checked,
-                        snapAnimationSpec = TweenSpec(durationMillis = 100),
-                        decayAnimationSpec = exponentialDecay(),
-                        anchors = DraggableAnchors {
-                            false at 0f
-                            true at maxBoundPx
-                        },
-                        positionalThreshold = { totalDistance -> totalDistance * 0.7f },
-                        velocityThreshold = { switchVelocityThresholdPx },
-                ),
-        )
-    }.apply {
-        this.checked = checked
     }
 }

--- a/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControlState.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/switch/source/BezierSwitchControlState.kt
@@ -1,0 +1,68 @@
+package io.channel.bezier.compose.component.switch.source
+
+import androidx.compose.animation.core.TweenSpec
+import androidx.compose.animation.core.exponentialDecay
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalFoundationApi::class)
+@Stable
+internal class BezierSwitchControlState(
+        initialChecked: Boolean,
+        val anchoredDraggableState: AnchoredDraggableState<Boolean>,
+) {
+    var checked by mutableStateOf(initialChecked)
+    var forceAnimationCheck by mutableStateOf(false)
+
+    suspend fun trySwitch(onCheckedChange: (Boolean) -> Unit) {
+        if (!anchoredDraggableState.isAnimationRunning) {
+            onCheckedChange(!anchoredDraggableState.currentValue)
+            anchoredDraggableState.animateTo(!anchoredDraggableState.currentValue)
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+internal fun rememberBezierSwitchControlState(checked: Boolean): BezierSwitchControlState {
+    /**
+     * 스위치에서 Thumb가 그려질 수 있는 너비는 양 옆 패딩을 제외한 38입니다.
+     * Thumb은 중앙 점을 기준으로 그리므로 22의 절반인 11에서 그리면 시작 점이 됩니다.
+     * 끝 점은 마찬가지로 끝에서 11만큼 멀어져야 하므로 38 - 11 = 27 에서 그려져야합니다.
+     * Thumb은 그려질 때 11을 항상 더하므로 계산식에서는 ThumbSize를 빼줍니다.
+     * 결과적으로 maxBound는 16이 되며 11을 더해서 27이 되었을 때 스위치 끝에 그려지게 됩니다.
+     */
+    val maxBound = SwitchWidth - SwitchPadding * 2 - ThumbSize
+    val maxBoundPx = with(LocalDensity.current) { maxBound.toPx() }
+
+    val switchVelocityThresholdPx = with(LocalDensity.current) { 10.dp.toPx() }
+
+    return remember {
+        BezierSwitchControlState(
+                initialChecked = checked,
+                anchoredDraggableState = AnchoredDraggableState(
+                        initialValue = checked,
+                        snapAnimationSpec = TweenSpec(durationMillis = 100),
+                        decayAnimationSpec = exponentialDecay(),
+                        anchors = DraggableAnchors {
+                            false at 0f
+                            true at maxBoundPx
+                        },
+                        positionalThreshold = { totalDistance -> totalDistance * 0.7f },
+                        velocityThreshold = { switchVelocityThresholdPx },
+                ),
+        )
+    }.apply {
+        this.checked = checked
+    }
+}


### PR DESCRIPTION
Switch 컴포넌트를 구현합니다.
- 상태가 현재 컴포넌트 상태와 맞지 않는다면 10초의 딜레이 이후 원래 상태로 되돌아갑니다.
- 상태가 되돌아가는 경우는 상태가 변경되었다는 callback을 주지 않습니다

코드 의도를 간략하게 남겨보면
- Control 에는 순수하게 on/off 의 역할을 부여했습니다.
- 되돌아가는 로직은 Control이 아닌 Switch에 부여했습니다.
Control은 좀 더 순수한 단위라고 생각되어서 UI를 표시하는 것 이외의 로직을 넣지 않으려 했습니다

<img width="313" alt="image" src="https://github.com/user-attachments/assets/952fbb9f-6e25-40d2-883b-3d4af11f9b56">
