### PR TITLE
progressSemantics 에서 ratio 읽지 않도록 변경

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/compose/component/progress_bar/BezierProgressBar.kt
+++ b/bezier/src/main/java/io/channel/bezier/compose/component/progress_bar/BezierProgressBar.kt
@@ -62,7 +62,7 @@ fun BezierProgressBar(
 
         Canvas(
                 modifier = Modifier
-                        .progressSemantics(progressRatio)
+                        .progressSemantics()
                         .fillMaxSize(),
         ) {
             drawRoundRect(


### PR DESCRIPTION
컨트리뷰트 해도 되나요?

지난 주에 발표 자료 준비할 때 발견했었는데, 테스트용으로 넣었던 코드가 남아있더라구요.
까먹기전에 고치려고 했는데 뒤늦게 생각이나서 올려봅니다

progressSemantics에 값을 넣으면 시각장애 대응으로 진행률을 추가적으로 음성으로 알려주는데요. (안넣으면 그냥 진행바라는 사실만 알려줌)
애니메이션 매 프레임마다 전달할 필요도 없을 뿐더러, 다수의 리컴포지션이 유발됩니다.

derivedState로 전달하는 방법도 있을 법 한데 그렇게까지 할 필요는 없을것 같아서 제거했습니다.