### PR TITLE
ripplealpha 고정값 지정

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
+++ b/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalRippleConfiguration
 import androidx.compose.material.RippleConfiguration
-import androidx.compose.material.RippleDefaults
+import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,8 +33,13 @@ fun BezierTheme(
     val contentColor = LocalContentColor.current
     val rippleConfiguration = remember(isDark, contentColor) {
         RippleConfiguration(
-                color = RippleDefaults.rippleColor(contentColor, isDark),
-                rippleAlpha = RippleDefaults.rippleAlpha(contentColor, isDark),
+                color = contentColor,
+                rippleAlpha = RippleAlpha(
+                        pressedAlpha = 0.24f,
+                        focusedAlpha = 0.24f,
+                        draggedAlpha = 0.16f,
+                        hoveredAlpha = 0.08f,
+                ),
         )
     }
     CompositionLocalProvider(


### PR DESCRIPTION
compose 기본 리플 알파가 너무 낮아서 리플 효과가 없는것처럼 보입니다. 기존 light 값을 가져와 적용합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 터치 피드백 상호작용 구성 요소 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->