### PR TITLE
fix more ripple alpha

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
+++ b/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
@@ -31,9 +31,9 @@ fun BezierTheme(
     }
 
     val contentColor = if (isDark) {
-        BezierTheme.colors.bgtxtAbsoluteWhiteNormal
+        colors.bgtxtAbsoluteWhiteNormal
     } else {
-        BezierTheme.colors.bgtxtAbsoluteBlackNormal
+        colors.bgtxtAbsoluteBlackNormal
     }
 
     val rippleConfiguration = remember(isDark, contentColor) {

--- a/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
+++ b/bezier/src/main/java/io/channel/bezier/BezierTheme.kt
@@ -30,15 +30,20 @@ fun BezierTheme(
         }
     }
 
-    val contentColor = LocalContentColor.current
+    val contentColor = if (isDark) {
+        BezierTheme.colors.bgtxtAbsoluteWhiteNormal
+    } else {
+        BezierTheme.colors.bgtxtAbsoluteBlackNormal
+    }
+
     val rippleConfiguration = remember(isDark, contentColor) {
         RippleConfiguration(
                 color = contentColor,
                 rippleAlpha = RippleAlpha(
-                        pressedAlpha = 0.24f,
-                        focusedAlpha = 0.24f,
-                        draggedAlpha = 0.16f,
-                        hoveredAlpha = 0.08f,
+                        pressedAlpha = 0.36f,
+                        focusedAlpha = 0.36f,
+                        draggedAlpha = 0.24f,
+                        hoveredAlpha = 0.12f,
                 ),
         )
     }


### PR DESCRIPTION
좀더 리플을 명시적으로 보일수있게 알파값을 조정하고, 다크모드일때 리플이 안보이므로 contentColor를 지정합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 다크 모드와 라이트 모드에서 텍스트 색상이 환경에 맞춰 더 명확하게 조정되어 가독성이 향상됩니다.
  * 터치/호버 등 피드백 효과(리플)가 전반적으로 강화되어 사용자 상호작용이 더 명확하게 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->