### PR TITLE
sample 모듈에 v3 컴포넌트 플레이그라운드 추가

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/IconButton.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/IconButton.kt
@@ -1,0 +1,268 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.typography.BezierTypo
+
+@Composable
+fun IconButton(
+        icon: BezierIcon,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        size: IconButtonSize = IconButtonSize.Medium,
+        variant: IconButtonVariant = IconButtonVariant.Ghost,
+        isActive: Boolean = false,
+        isLoading: Boolean = false,
+        enabled: Boolean = true,
+        contentDescription: String? = null,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colorSpec = iconButtonColorSpec(variant)
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val showOverlay = (isPressed || isActive) && variant == IconButtonVariant.Ghost
+    val containerAlpha = if (enabled) 1f else 0.4f
+
+    Box(
+            modifier = modifier
+                    .size(size.containerLength)
+                    .graphicsLayer(alpha = containerAlpha)
+                    .clip(CircleShape)
+                    .then(
+                            if (colorSpec.background != null) Modifier.background(colorSpec.background)
+                            else Modifier,
+                    )
+                    .then(
+                            if (showOverlay) Modifier.background(Color.Black.copy(alpha = 0.05f))
+                            else Modifier,
+                    )
+                    .clickable(
+                            interactionSource = interactionSource,
+                            indication = null,
+                            enabled = enabled && !isLoading,
+                            onClick = onClick,
+                    ),
+            contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+                modifier = Modifier
+                        .alpha(if (isLoading) 0f else 1f)
+                        .size(size.iconLength),
+                imageVector = icon.imageVector,
+                tint = colorSpec.iconColor,
+                contentDescription = contentDescription,
+        )
+        if (isLoading) {
+            CircularProgressIndicator(
+                    modifier = Modifier.size(size.spinnerLength),
+                    color = colorSpec.iconColor,
+                    backgroundColor = BezierTheme.colorsV3.borderNeutral,
+                    strokeWidth = 2.dp,
+            )
+        }
+    }
+}
+
+enum class IconButtonSize {
+    Xsmall,
+    Small,
+    Medium,
+    Large;
+
+    internal val containerLength: Dp
+        get() = when (this) {
+            Xsmall -> 20.dp
+            Small -> 24.dp
+            Medium -> 32.dp
+            Large -> 44.dp
+        }
+
+    internal val padding: Dp
+        get() = when (this) {
+            Xsmall -> 2.dp
+            Small -> 4.dp
+            Medium -> 6.dp
+            Large -> 12.dp
+        }
+
+    internal val iconLength: Dp
+        get() = containerLength - padding * 2
+
+    internal val spinnerLength: Dp
+        get() = when (this) {
+            Xsmall -> 12.dp
+            Small -> 14.dp
+            Medium -> 16.dp
+            Large -> 18.dp
+        }
+}
+
+enum class IconButtonVariant {
+    Ghost,
+    Filled,
+}
+
+internal data class IconButtonColorSpec(
+        val background: Color?,
+        val iconColor: Color,
+)
+
+@Composable
+internal fun iconButtonColorSpec(variant: IconButtonVariant): IconButtonColorSpec {
+    val colors = BezierTheme.colorsV3
+    return when (variant) {
+        IconButtonVariant.Ghost -> IconButtonColorSpec(
+                background = null,
+                iconColor = colors.iconNeutral,
+        )
+        IconButtonVariant.Filled -> IconButtonColorSpec(
+                background = colors.fillNeutralLight,
+                iconColor = colors.iconNeutralHeavy,
+        )
+    }
+}
+
+@Composable
+private fun pressedInteractionSource(): MutableInteractionSource {
+    val source = remember { MutableInteractionSource() }
+    LaunchedEffect(source) {
+        source.emit(PressInteraction.Press(Offset.Zero))
+    }
+    return source
+}
+
+@Composable
+private fun IconButtonMatrix(size: IconButtonSize, sizeLabel: String) {
+    val labelColWidth = 88.dp
+    val cellWidth = 96.dp
+
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(modifier = Modifier.width(labelColWidth * 2))
+                listOf("default", "pressed", "active", "disabled", "loading").forEach { stateLabel ->
+                    Box(
+                            modifier = Modifier.width(cellWidth),
+                            contentAlignment = Alignment.Center,
+                    ) {
+                        BezierText(
+                                text = stateLabel,
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                }
+            }
+
+            IconButtonVariant.values().forEachIndexed { variantIndex, variant ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                            modifier = Modifier.width(labelColWidth),
+                            contentAlignment = Alignment.CenterStart,
+                    ) {
+                        if (variantIndex == 0) {
+                            BezierText(
+                                    text = sizeLabel,
+                                    typo = BezierTypo.TextMedium,
+                                    color = BezierTheme.colorsV3.textNeutral,
+                            )
+                        }
+                    }
+                    Box(
+                            modifier = Modifier.width(labelColWidth),
+                            contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BezierText(
+                                text = variant.name.lowercase(),
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                    IconButtonCell(cellWidth) {
+                        IconButton(icon = BezierIcons.Plus, onClick = {}, size = size, variant = variant)
+                    }
+                    IconButtonCell(cellWidth) {
+                        IconButton(icon = BezierIcons.Plus, onClick = {}, size = size, variant = variant, interactionSource = pressedInteractionSource())
+                    }
+                    IconButtonCell(cellWidth) {
+                        IconButton(icon = BezierIcons.Plus, onClick = {}, size = size, variant = variant, isActive = true)
+                    }
+                    IconButtonCell(cellWidth) {
+                        IconButton(icon = BezierIcons.Plus, onClick = {}, size = size, variant = variant, enabled = false)
+                    }
+                    IconButtonCell(cellWidth) {
+                        IconButton(icon = BezierIcons.Plus, onClick = {}, size = size, variant = variant, isLoading = true)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconButtonCell(width: Dp, content: @Composable () -> Unit) {
+    Box(
+            modifier = Modifier.width(width),
+            contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+@Preview(showBackground = true, widthDp = 700)
+@Composable
+private fun IconButtonMatrixXsmallPreview() = IconButtonMatrix(IconButtonSize.Xsmall, "xsmall")
+
+@Preview(showBackground = true, widthDp = 700)
+@Composable
+private fun IconButtonMatrixSmallPreview() = IconButtonMatrix(IconButtonSize.Small, "small")
+
+@Preview(showBackground = true, widthDp = 700)
+@Composable
+private fun IconButtonMatrixMediumPreview() = IconButtonMatrix(IconButtonSize.Medium, "medium")
+
+@Preview(showBackground = true, widthDp = 700)
+@Composable
+private fun IconButtonMatrixLargePreview() = IconButtonMatrix(IconButtonSize.Large, "large")
+
+@Preview(showBackground = true, widthDp = 700)
+@Preview(showBackground = true, widthDp = 700, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun IconButtonMatrixMediumDarkPreview() = IconButtonMatrix(IconButtonSize.Medium, "medium")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycle-runtime-ktx = "2.10.0"
 activity-compose = "1.12.2"
 compose-bom = "2025.12.01"
 coil = "2.4.0"
+navigation3 = "1.1.2"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -27,6 +28,8 @@ ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 material = { group = "androidx.compose.material", name = "material" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
+navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
+navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     implementation(libs.ui.graphics)
     implementation(libs.ui.tooling.preview)
     implementation(libs.material)
+    implementation(libs.navigation3.runtime)
+    implementation(libs.navigation3.ui)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -3,37 +3,52 @@ package io.channel.bezier.compose.sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.*
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
 import io.channel.bezier.BezierTheme
+import io.channel.bezier.compose.sample.playground.ButtonPlaygroundKey
+import io.channel.bezier.compose.sample.playground.ButtonPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.ComponentListKey
+import io.channel.bezier.compose.sample.playground.ComponentListScreen
+import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
+import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            // A surface container using the 'background' color from the theme
-            Greeting("Android")
+            PlaygroundApp()
         }
     }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
+private fun PlaygroundApp() {
     BezierTheme {
-        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
-            Text(
-                    text = "Hello $name!",
-                    modifier = modifier,
-            )
-        }
+        val backStack = remember { mutableStateListOf<Any>(ComponentListKey) }
+        NavDisplay(
+                modifier = Modifier.statusBarsPadding(),
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                entryProvider = entryProvider {
+                    entry<ComponentListKey> {
+                        ComponentListScreen(
+                                onSelectButton = { backStack.add(ButtonPlaygroundKey) },
+                                onSelectIconButton = { backStack.add(IconButtonPlaygroundKey) },
+                        )
+                    }
+                    entry<ButtonPlaygroundKey> {
+                        ButtonPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                    }
+                    entry<IconButtonPlaygroundKey> {
+                        IconButtonPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                    }
+                },
+        )
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    Greeting("Android")
 }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -3,7 +3,11 @@ package io.channel.bezier.compose.sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -20,6 +24,7 @@ import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
             PlaygroundApp()
@@ -30,25 +35,31 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun PlaygroundApp() {
     BezierTheme {
-        val backStack = remember { mutableStateListOf<Any>(ComponentListKey) }
-        NavDisplay(
-                modifier = Modifier.statusBarsPadding(),
-                backStack = backStack,
-                onBack = { backStack.removeLastOrNull() },
-                entryProvider = entryProvider {
-                    entry<ComponentListKey> {
-                        ComponentListScreen(
-                                onSelectButton = { backStack.add(ButtonPlaygroundKey) },
-                                onSelectIconButton = { backStack.add(IconButtonPlaygroundKey) },
-                        )
-                    }
-                    entry<ButtonPlaygroundKey> {
-                        ButtonPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
-                    }
-                    entry<IconButtonPlaygroundKey> {
-                        IconButtonPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
-                    }
-                },
-        )
+        Box(
+                modifier = Modifier
+                        .fillMaxSize()
+                        .background(BezierTheme.colorsV3.surface),
+        ) {
+            val backStack = remember { mutableStateListOf<Any>(ComponentListKey) }
+            NavDisplay(
+                    modifier = Modifier.systemBarsPadding(),
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+                    entryProvider = entryProvider {
+                        entry<ComponentListKey> {
+                            ComponentListScreen(
+                                    onSelectButton = { backStack.add(ButtonPlaygroundKey) },
+                                    onSelectIconButton = { backStack.add(IconButtonPlaygroundKey) },
+                            )
+                        }
+                        entry<ButtonPlaygroundKey> {
+                            ButtonPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<IconButtonPlaygroundKey> {
+                            IconButtonPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                    },
+            )
+        }
     }
 }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ButtonPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ButtonPlaygroundScreen.kt
@@ -1,0 +1,101 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.v3.component.Button
+import io.channel.bezier.v3.component.ButtonSemantic
+import io.channel.bezier.v3.component.ButtonSize
+import io.channel.bezier.v3.component.ButtonVariant
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun ButtonPlaygroundScreen(onBack: () -> Unit) {
+    var size by remember { mutableStateOf(ButtonSize.Medium) }
+    var variant by remember { mutableStateOf(ButtonVariant.Filled) }
+    var semantic by remember { mutableStateOf(ButtonSemantic.Primary) }
+    var isActive by remember { mutableStateOf(false) }
+    var isLoading by remember { mutableStateOf(false) }
+    var enabled by remember { mutableStateOf(true) }
+    var showLeadingIcon by remember { mutableStateOf(true) }
+    var showTrailingIcon by remember { mutableStateOf(true) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Button") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Button(
+                        text = "Label",
+                        onClick = {},
+                        size = size,
+                        variant = variant,
+                        semantic = semantic,
+                        isActive = isActive,
+                        isLoading = isLoading,
+                        enabled = enabled,
+                        leadingIcon = if (showLeadingIcon) BezierIcons.Plus else null,
+                        trailingIcon = if (showTrailingIcon) BezierIcons.Plus else null,
+                )
+            }
+
+            Divider()
+
+            EnumControl("Size", ButtonSize.values(), size) { size = it }
+            EnumControl("Variant", ButtonVariant.values(), variant) { variant = it }
+            EnumControl("Semantic", ButtonSemantic.values(), semantic) { semantic = it }
+            BooleanControl("isActive", isActive) { isActive = it }
+            BooleanControl("isLoading", isLoading) { isLoading = it }
+            BooleanControl("enabled", enabled) { enabled = it }
+            BooleanControl("leadingIcon", showLeadingIcon) { showLeadingIcon = it }
+            BooleanControl("trailingIcon", showTrailingIcon) { showTrailingIcon = it }
+        }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -1,0 +1,48 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ComponentListScreen(
+        onSelectButton: () -> Unit,
+        onSelectIconButton: () -> Unit,
+) {
+    Scaffold(
+            topBar = { TopAppBar(title = { Text("v3 Components") }) },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize(),
+        ) {
+            ComponentRow("Button", onClick = onSelectButton)
+            Divider()
+            ComponentRow("IconButton", onClick = onSelectIconButton)
+            Divider()
+        }
+    }
+}
+
+@Composable
+private fun ComponentRow(name: String, onClick: () -> Unit) {
+    Box(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onClick)
+                    .padding(16.dp),
+    ) {
+        Text(text = name)
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/IconButtonPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/IconButtonPlaygroundScreen.kt
@@ -1,0 +1,89 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun IconButtonPlaygroundScreen(onBack: () -> Unit) {
+    var size by remember { mutableStateOf(IconButtonSize.Medium) }
+    var variant by remember { mutableStateOf(IconButtonVariant.Ghost) }
+    var isActive by remember { mutableStateOf(false) }
+    var isLoading by remember { mutableStateOf(false) }
+    var enabled by remember { mutableStateOf(true) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("IconButton") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                IconButton(
+                        icon = BezierIcons.Plus,
+                        onClick = {},
+                        size = size,
+                        variant = variant,
+                        isActive = isActive,
+                        isLoading = isLoading,
+                        enabled = enabled,
+                        contentDescription = "Sample",
+                )
+            }
+
+            Divider()
+
+            EnumControl("Size", IconButtonSize.values(), size) { size = it }
+            EnumControl("Variant", IconButtonVariant.values(), variant) { variant = it }
+            BooleanControl("isActive", isActive) { isActive = it }
+            BooleanControl("isLoading", isLoading) { isLoading = it }
+            BooleanControl("enabled", enabled) { enabled = it }
+        }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -1,0 +1,7 @@
+package io.channel.bezier.compose.sample.playground
+
+data object ComponentListKey
+
+data object ButtonPlaygroundKey
+
+data object IconButtonPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/PlaygroundControls.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/PlaygroundControls.kt
@@ -1,0 +1,76 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun <T> EnumControl(
+        label: String,
+        options: Array<T>,
+        selected: T,
+        optionLabel: (T) -> String = { it.toString() },
+        onSelected: (T) -> Unit,
+) {
+    Column(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Text(text = label, fontWeight = FontWeight.Bold)
+        FlowRow(verticalArrangement = Arrangement.Center) {
+            options.forEach { option ->
+                Row(
+                        modifier = Modifier
+                                .selectable(
+                                        selected = option == selected,
+                                        onClick = { onSelected(option) },
+                                )
+                                .padding(end = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(
+                            selected = option == selected,
+                            onClick = { onSelected(option) },
+                    )
+                    Text(
+                            text = optionLabel(option),
+                            modifier = Modifier.padding(start = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun BooleanControl(
+        label: String,
+        value: Boolean,
+        onValueChange: (Boolean) -> Unit,
+) {
+    Row(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, fontWeight = FontWeight.Bold)
+        Switch(checked = value, onCheckedChange = onValueChange)
+    }
+}


### PR DESCRIPTION
## Summary
- Navigation 3 (1.1.2) 도입 — `NavDisplay` + `entryProvider`, `data object` 기반 NavKey
- 컴포넌트 목록 → Button / IconButton 인터랙티브 플레이그라운드 (size/variant/semantic 라디오 + boolean 토글)
- top bar 뒤로가기 버튼은 v3 \`IconButton(Ghost, Medium)\` 자체 사용 (Material extended-icons 의존성 미추가)
- 시스템 status bar 침범 방지 (\`Modifier.statusBarsPadding()\`)

> 📌 이 PR은 #141 (IconButton 추가) 위에 stack 되어 있습니다. #141 머지 후 base를 \`v3\`로 변경하거나 자동 rebase 됩니다.

## Test plan
- [ ] \`:sample:installDebug\` 실기기에서 실행 → 목록 → Button / IconButton 진입 → 토글 인터랙션 확인
- [ ] Status bar 가 헤더와 겹치지 않는지
- [ ] 뒤로가기 동작 (top bar back 버튼)

🤖 Generated with [Claude Code](https://claude.com/claude-code)