### PR TITLE
v3 패키지에 Badge 컴포넌트 신규 추가

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Badge.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Badge.kt
@@ -1,0 +1,336 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.dimension.BezierFontSize
+import io.channel.bezier.dimension.BezierLetterSpacing
+import io.channel.bezier.dimension.BezierLineHeight
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+@Composable
+fun Badge(
+        label: String,
+        modifier: Modifier = Modifier,
+        size: BadgeSize = BadgeSize.Xsmall,
+        color: BadgeColor = BadgeColor.Default,
+        iconSource: BezierIcon? = null,
+) {
+    val layout = size.layout
+    val colorSpec = badgeColorSpec(color)
+
+    Box(
+            modifier = modifier
+                    .clip(RoundedCornerShape(BadgeCornerRadius))
+                    .background(colorSpec.background)
+                    .padding(horizontal = layout.horizontalPadding, vertical = layout.verticalPadding),
+            contentAlignment = Alignment.Center,
+    ) {
+        Row(
+                horizontalArrangement = Arrangement.spacedBy(BadgeIconTextGap),
+                verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (iconSource != null) {
+                Icon(
+                        modifier = Modifier.size(BadgeIconLength),
+                        imageVector = iconSource.imageVector,
+                        tint = colorSpec.iconColor,
+                        contentDescription = null,
+                )
+            }
+            Box(modifier = Modifier.padding(horizontal = layout.textInnerHorizontalPadding)) {
+                BadgeText(text = label, size = size, color = colorSpec.textColor)
+            }
+        }
+    }
+}
+
+@Composable
+private fun BadgeText(text: String, size: BadgeSize, color: Color) {
+    when (size) {
+        BadgeSize.Xsmall -> BezierText(
+                text = text,
+                typo = BezierTypo.TextXSmall,
+                weight = BezierWeight.Regular,
+                color = color,
+        )
+
+        BadgeSize.Small -> BezierText(
+                text = text,
+                typo = BezierTypo.TextMedium,
+                weight = BezierWeight.Regular,
+                color = color,
+        )
+
+        BadgeSize.Medium -> Text(
+                text = text,
+                style = TextStyle(
+                        fontSize = BezierFontSize.Size15,
+                        lineHeight = BezierLineHeight.Size18,
+                        letterSpacing = BezierLetterSpacing.Tight,
+                        fontWeight = FontWeight.Normal,
+                        color = color,
+                ),
+        )
+
+        BadgeSize.Large -> Text(
+                text = text,
+                style = TextStyle(
+                        fontSize = BezierFontSize.Size16,
+                        lineHeight = BezierLineHeight.Size20,
+                        letterSpacing = BezierLetterSpacing.Tight,
+                        fontWeight = FontWeight.Normal,
+                        color = color,
+                ),
+        )
+    }
+}
+
+private val BadgeIconLength: Dp = 16.dp
+private val BadgeIconTextGap: Dp = 0.dp
+private val BadgeCornerRadius: Dp = 32.dp
+
+enum class BadgeSize {
+    Xsmall,
+    Small,
+    Medium,
+    Large;
+
+    internal val layout: BadgeLayoutSpec
+        get() = when (this) {
+            Xsmall -> BadgeLayoutSpec(
+                    horizontalPadding = 4.dp,
+                    verticalPadding = 1.dp,
+                    textInnerHorizontalPadding = 4.dp,
+            )
+
+            Small -> BadgeLayoutSpec(
+                    horizontalPadding = 4.dp,
+                    verticalPadding = 2.dp,
+                    textInnerHorizontalPadding = 4.dp,
+            )
+
+            Medium -> BadgeLayoutSpec(
+                    horizontalPadding = 4.dp,
+                    verticalPadding = 2.dp,
+                    textInnerHorizontalPadding = 4.dp,
+            )
+
+            Large -> BadgeLayoutSpec(
+                    horizontalPadding = 4.dp,
+                    verticalPadding = 3.dp,
+                    textInnerHorizontalPadding = 4.dp,
+            )
+        }
+}
+
+enum class BadgeColor {
+    Default,
+    MonochromeLight,
+    MonochromeDark,
+    Blue,
+    Cobalt,
+    Teal,
+    Green,
+    Olive,
+    Pink,
+    Navy,
+    Yellow,
+    Orange,
+    Red,
+    Purple,
+}
+
+internal data class BadgeLayoutSpec(
+        val horizontalPadding: Dp,
+        val verticalPadding: Dp,
+        val textInnerHorizontalPadding: Dp,
+)
+
+internal data class BadgeColorSpec(
+        val background: Color,
+        val textColor: Color,
+        val iconColor: Color,
+)
+
+@Composable
+internal fun badgeColorSpec(color: BadgeColor): BadgeColorSpec {
+    val colors = BezierTheme.colorsV3
+    return when (color) {
+        BadgeColor.Default -> BadgeColorSpec(
+                background = colors.fillNeutralLight,
+                textColor = colors.textNeutral,
+                iconColor = colors.textNeutralLight,
+        )
+
+        BadgeColor.MonochromeLight -> BadgeColorSpec(
+                background = colors.fillNeutralLight,
+                textColor = colors.textNeutralLighter,
+                iconColor = colors.iconNeutral,
+        )
+
+        BadgeColor.MonochromeDark -> BadgeColorSpec(
+                background = colors.fillNeutralHeavier,
+                textColor = colors.textAbsoluteWhite,
+                iconColor = colors.iconAbsoluteWhite,
+        )
+
+        BadgeColor.Blue -> BadgeColorSpec(
+                background = colors.fillAccentBlueHeavy,
+                textColor = colors.textAccentBlue,
+                iconColor = colors.iconAccentBlue,
+        )
+
+        BadgeColor.Cobalt -> BadgeColorSpec(
+                background = colors.fillAccentCobaltHeavy,
+                textColor = colors.textAccentCobalt,
+                iconColor = colors.iconAccentCobalt,
+        )
+
+        BadgeColor.Teal -> BadgeColorSpec(
+                background = colors.fillAccentTealHeavy,
+                textColor = colors.textAccentTeal,
+                iconColor = colors.iconAccentTeal,
+        )
+
+        BadgeColor.Green -> BadgeColorSpec(
+                background = colors.fillAccentGreenHeavy,
+                textColor = colors.textAccentGreen,
+                iconColor = colors.iconAccentGreen,
+        )
+
+        BadgeColor.Olive -> BadgeColorSpec(
+                background = colors.fillAccentOliveHeavy,
+                textColor = colors.textAccentOlive,
+                iconColor = colors.iconAccentOlive,
+        )
+
+        BadgeColor.Pink -> BadgeColorSpec(
+                background = colors.fillAccentPinkHeavy,
+                textColor = colors.textAccentPink,
+                iconColor = colors.iconAccentPink,
+        )
+
+        BadgeColor.Navy -> BadgeColorSpec(
+                background = colors.fillAccentNavyHeavy,
+                textColor = colors.textAccentNavy,
+                iconColor = colors.iconAccentNavy,
+        )
+
+        BadgeColor.Yellow -> BadgeColorSpec(
+                background = colors.fillAccentYellowHeavy,
+                textColor = colors.textAccentYellow,
+                iconColor = colors.iconAccentYellow,
+        )
+
+        BadgeColor.Orange -> BadgeColorSpec(
+                background = colors.fillAccentOrangeHeavy,
+                textColor = colors.textAccentOrange,
+                iconColor = colors.iconAccentOrange,
+        )
+
+        BadgeColor.Red -> BadgeColorSpec(
+                background = colors.fillAccentRedHeavy,
+                textColor = colors.textAccentRed,
+                iconColor = colors.iconAccentRed,
+        )
+
+        BadgeColor.Purple -> BadgeColorSpec(
+                background = colors.fillAccentPurpleHeavy,
+                textColor = colors.textAccentPurple,
+                iconColor = colors.iconAccentPurple,
+        )
+    }
+}
+
+@Composable
+private fun BadgeMatrix(size: BadgeSize, sizeLabel: String) {
+    val labelColWidth = 132.dp
+    val cellWidth = 132.dp
+
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(modifier = Modifier.width(labelColWidth))
+                listOf("no icon", "with icon").forEach { headerLabel ->
+                    Box(modifier = Modifier.width(cellWidth), contentAlignment = Alignment.CenterStart) {
+                        BezierText(
+                                text = headerLabel,
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                }
+            }
+
+            BadgeColor.values().forEachIndexed { idx, badgeColor ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(modifier = Modifier.width(labelColWidth), contentAlignment = Alignment.CenterStart) {
+                        BezierText(
+                                text = if (idx == 0) "$sizeLabel — ${badgeColor.name}" else badgeColor.name,
+                                typo = BezierTypo.TextMedium,
+                                weight = if (idx == 0) BezierWeight.Bold else BezierWeight.Regular,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                    Box(modifier = Modifier.width(cellWidth), contentAlignment = Alignment.CenterStart) {
+                        Badge(label = "Badge", size = size, color = badgeColor)
+                    }
+                    Box(modifier = Modifier.width(cellWidth), contentAlignment = Alignment.CenterStart) {
+                        Badge(label = "Badge", size = size, color = badgeColor, iconSource = BezierIcons.Plus)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 600)
+@Composable
+private fun BadgeMatrixXsmallPreview() = BadgeMatrix(BadgeSize.Xsmall, "xsmall")
+
+@Preview(showBackground = true, widthDp = 600)
+@Composable
+private fun BadgeMatrixSmallPreview() = BadgeMatrix(BadgeSize.Small, "small")
+
+@Preview(showBackground = true, widthDp = 600)
+@Composable
+private fun BadgeMatrixMediumPreview() = BadgeMatrix(BadgeSize.Medium, "medium")
+
+@Preview(showBackground = true, widthDp = 600)
+@Composable
+private fun BadgeMatrixLargePreview() = BadgeMatrix(BadgeSize.Large, "large")
+
+@Preview(showBackground = true, widthDp = 600, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun BadgeMatrixMediumDarkPreview() = BadgeMatrix(BadgeSize.Medium, "medium")

--- a/docs/components/Badge/SPEC.md
+++ b/docs/components/Badge/SPEC.md
@@ -1,0 +1,250 @@
+# Badge Spec
+
+> Figma: [🚧 Mobile Components — Badge](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1729-170&m=dev)
+> Figma node ID: `1729:170`
+> Design spec doc: [channel-io/design-team — Badge-spec.md](https://github.com/channel-io/design-team/blob/main/specs/components/Badge-spec.md)
+
+목록·카드 UI에서 항목의 상태나 속성을 색상과 텍스트로 즉각 전달하는 인라인 레이블.
+
+- **모양**: 알약형(pill). 모서리 반경 32.
+- **인터랙션**: 읽기 전용. 사용자가 제거할 수 있어야 한다면 Tag 컴포넌트 사용.
+- **State**: Figma에 state property 없음 (default만 존재). pressed/active/disabled/loading 없음.
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property는 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **size** | `xsmall` / `small` / `medium` / `large` | 크기 축 |
+| **color** | `default` / `monochrome-light` / `monochrome-dark` / `blue` / `cobalt` / `teal` / `green` / `olive` / `pink` / `navy` / `yellow` / `orange` / `red` / `purple` | 의미 색상 축 — green=성공·활성 / red=오류·긴급 / orange=경고 / blue=정보·진행 / monochrome-light=비활성·초안 |
+
+총 instance: `4 × 14 = 56개` (Figma 노출 인스턴스 수와 일치)
+
+추가 인스턴스 토글 props (Figma component property 기준):
+
+| Toggle/Slot | 기본값 | 효과 |
+|---|---|---|
+| `hasIcon` | `false` | true 면 leading 위치에 16dp 아이콘 슬롯 표시 |
+| `iconSource` | (없음) | `hasIcon = true`일 때 표시할 아이콘 소스. 기본 placeholder는 Figma asset `icon/plus` |
+| `label` | `"Badge"` | 본문 텍스트 |
+
+---
+
+## 2. Size 별 Spec
+
+단위는 Android 관용에 따라 `dp` (텍스트는 `sp`로 해석).
+
+| Size | Height | Horizontal Padding | Vertical Padding | BadgeText Inner H-Padding | Icon ↔ Text Gap | Icon Length | Corner Radius |
+|---|---|---|---|---|---|---|---|
+| `xsmall` | 18 | 4 | 1 | 4 | 0 | 16 | 32 (full pill) |
+| `small`  | 22 | 4 | 2 | 4 | 0 | 16 | 32 (full pill) |
+| `medium` | 22 | 4 | 2 | 4 | 0 | 16 | 32 (full pill) |
+| `large`  | 26 | 4 | 3 | 4 | 0 | 16 | 32 (full pill) |
+
+- `Icon Length`는 모든 size에서 16으로 고정.
+- `Icon ↔ Text Gap`은 컨테이너 auto-layout에 명시적 `gap` 없음(0).
+- Corner radius는 Variable `radius/32` (32 dp).
+
+### 폰트 (공통)
+
+- Family: `Inter` (Variable `text/font-family`)
+- Weight: `Regular` (Variable `text/weight/regular` = 400)
+- Style: not italic
+
+---
+
+## 3. Color 별 컬러 토큰
+
+이 컴포넌트는 모든 size에서 동일한 color 토큰을 사용한다 (Figma 확인). Border 사용 없음.
+
+### Background
+
+| Color | Variable | Raw |
+|---|---|---|
+| `default` | `color/fill/neutral/light` | `#0000000d` |
+| `monochrome-light` | `color/fill/neutral/light` | `#0000000d` |
+| `monochrome-dark` | `color/fill/neutral/heavier` | `#00000066` |
+| `blue` | `color/fill/accent/blue/heavy` | `#6157ea33` |
+| `cobalt` | `color/fill/accent/cobalt/heavy` | `#3292e333` |
+| `teal` | `color/fill/accent/teal/heavy` | `#09b2ac33` |
+| `green` | `color/fill/accent/green/heavy` | `#20ab5533` |
+| `olive` | `color/fill/accent/olive/heavy` | `#a9b11033` |
+| `pink` | `color/fill/accent/pink/heavy` | `#d64bb533` |
+| `navy` | `color/fill/accent/navy/heavy` | `#424fab33` |
+| `yellow` | `color/fill/accent/yellow/heavy` | `#edae0d33` |
+| `orange` | `color/fill/accent/orange/heavy` | `#e67f2b33` |
+| `red` | `color/fill/accent/red/heavy` | `#e1535d33` |
+| `purple` | `color/fill/accent/purple/heavy` | `#8e57e733` |
+
+> `default`와 `monochrome-light`의 Background 토큰은 동일하다. 두 색상의 차이는 텍스트 색상에서 발생한다.
+
+### Text color
+
+| Color | Variable | Raw |
+|---|---|---|
+| `default` | `color/text/neutral` | `#000000d9` |
+| `monochrome-light` | `color/text/neutral/lighter` | `#00000066` |
+| `monochrome-dark` | `color/text/absolute/white` | `#ffffff` |
+| `blue` | `color/text/accent/blue` | `#6157ea` |
+| `cobalt` | `color/text/accent/cobalt` | `#3292e3` |
+| `teal` | `color/text/accent/teal` | `#09b2ac` |
+| `green` | `color/text/accent/green` | `#20ab55` |
+| `olive` | `color/text/accent/olive` | `#a9b110` |
+| `pink` | `color/text/accent/pink` | `#d64bb5` |
+| `navy` | `color/text/accent/navy` | `#424fab` |
+| `yellow` | `color/text/accent/yellow` | `#edae0d` |
+| `orange` | `color/text/accent/orange` | `#e67f2b` |
+| `red` | `color/text/accent/red` | `#e1535d` |
+| `purple` | `color/text/accent/purple` | `#8e57e7` |
+
+### Icon color
+
+`hasIcon=true` 인스턴스에서만 노출되는 토큰. text와 icon이 서로 다른 토큰을 쓰는 경우가 있어 분리 표로 명시한다.
+
+| Color | Variable | Raw | 텍스트와의 차이 |
+|---|---|---|---|
+| `default` | `color/text/neutral/light` | `#00000099` | text는 `color/text/neutral` (#000000d9). icon이 alpha 0.6, text가 alpha 0.85 — 다름 |
+| `monochrome-light` | `color/icon/neutral` | `#00000066` | text는 `color/text/neutral/lighter` (#00000066). hex 동일, 토큰 이름 다름 |
+| `monochrome-dark` | `color/icon/absolute/white` | `#ffffff` | text는 `color/text/absolute/white` (#ffffff). hex 동일, 토큰 이름 다름 |
+| `blue` | `color/icon/accent/blue` | `#6157ea` | text는 `color/text/accent/blue` (#6157ea). hex 동일, 토큰 이름 다름 |
+| `cobalt` | `color/icon/accent/cobalt` | `#3292e3` | text와 hex 동일, 토큰 이름 다름 |
+| `teal` | `color/icon/accent/teal` | `#09b2ac` | text와 hex 동일, 토큰 이름 다름 |
+| `green` | `color/icon/accent/green` | `#20ab55` | text와 hex 동일, 토큰 이름 다름 |
+| `olive` | `color/icon/accent/olive` | `#a9b110` | text와 hex 동일, 토큰 이름 다름 |
+| `pink` | `color/icon/accent/pink` | `#d64bb5` | text와 hex 동일, 토큰 이름 다름 |
+| `navy` | `color/icon/accent/navy` | `#424fab` | text와 hex 동일, 토큰 이름 다름 |
+| `yellow` | `color/icon/accent/yellow` | `#edae0d` | text와 hex 동일, 토큰 이름 다름 |
+| `orange` | `color/icon/accent/orange` | `#e67f2b` | text와 hex 동일, 토큰 이름 다름 |
+| `red` | `color/icon/accent/red` | `#e1535d` | text와 hex 동일, 토큰 이름 다름 |
+| `purple` | `color/icon/accent/purple` | `#8e57e7` | text와 hex 동일, 토큰 이름 다름 |
+
+### Border
+
+Badge는 모든 color/size에서 border를 사용하지 않는다 (Figma 노드에 border 정의 없음).
+
+---
+
+## 4. Typography
+
+이 컴포넌트의 텍스트 노드를 두 케이스로 분리해 기재한다.
+
+### Case A — Typography Token 사용
+
+Figma text style이 design system token으로 등록된 케이스.
+
+| 위치 | Token | Figma Style 이름 | 구성 |
+|---|---|---|---|
+| BadgeText (size=xsmall) | `Typography/text/xsmall` | `Typography/text/xsmall` | family=`text/font-family` · weight=`text/weight/regular` (400) · size=`text/size/xsmall` (12) · line-height=`text/line-height/xsmall` (16) · letter-spacing=`text/letter-spacing` (0) |
+| BadgeText (size=small) | `Typography/text/medium` | `Typography/text/medium` | family=`text/font-family` · weight=`text/weight/regular` (400) · size=`text/size/medium` (14) · line-height=`text/line-height/medium` (18) · letter-spacing=`text/letter-spacing` (0) |
+
+### Case B — Custom Typography (토큰 미적용)
+
+Figma text style이 token 없이 raw 값으로 직접 지정된 케이스. 5요소 모두 명시.
+
+| 위치 | Font | Size | Weight | Line Height | Letter Spacing | Custom 사유 |
+|---|---|---|---|---|---|---|
+| BadgeText (size=medium) | Inter | 15 | 400 | 18 | -0.1 | Figma description에 토큰 미적용 사유 명시 없음. Variable 단위로는 모두 토큰(`text/size/large` · `text/line-height/medium` · `text/letter-spacing/tight`)이지만 조합으로서의 Typography 토큰이 등록되어 있지 않음. 디자이너 확인 필요 |
+| BadgeText (size=large)  | Inter | 16 | 400 | 20 | -0.1 | Figma description에 토큰 미적용 사유 명시 없음. Variable 단위로는 모두 토큰(`text/size/xlarge` · `text/line-height/large` · `text/letter-spacing/tight`)이지만 조합으로서의 Typography 토큰이 등록되어 있지 않음. 디자이너 확인 필요 |
+
+> 회색 지대: medium/large 폰트 조합은 Variable 토큰으로는 정의되어 있으나 묶음 Typography 스타일로는 미등록 상태. 디자이너에게 Typography 토큰 등록 여부 확인 필요.
+
+---
+
+## 5. 아이콘 자산 (hasIcon = true 시)
+
+| 항목 | 값 |
+|---|---|
+| Figma asset 이름 | `icon/plus` (Figma 노드의 `data-name`) |
+| 크기 | 16 × 16 dp |
+| 내부 shape inset | `inset[12.5%]` (실제 visible content는 16의 75% = 12 dp 정사각형) |
+| 색상 적용 방식 | Figma 노드에서는 image asset으로 인라인 |
+
+> Figma의 placeholder asset이 `icon/plus`인 것이지, 실제 사용 시에는 임의 아이콘 소스를 `iconSource`로 전달한다.
+
+---
+
+## 6. 디자이너 가이드라인 (Figma 컴포넌트 description 인용)
+
+Figma component description에 적힌 그대로:
+
+- 목록·카드 UI에서 항목의 상태나 속성을 색상과 텍스트로 즉각 전달하는 인라인 레이블.
+- color 의미: green=성공·활성 / red=오류·긴급 / orange=경고 / blue=정보·진행 / monochrome-light=비활성·초안
+- size: large / medium / small / xsmall
+- hasIcon(옵션): true 시 leadingIconSource 아이콘 표시
+- 사용자가 제거할 수 있으면 Tag 사용. Badge는 항상 읽기 전용.
+
+---
+
+## 7. Variant 매트릭스
+
+총 instance: `4 (size) × 14 (color) = 56개` (hasIcon은 별도 toggle, state 축 없음)
+
+### 컴포넌트 정의 노드 ID (56개, hasIcon=false 기본 상태)
+
+Color 가로 정렬 순서 (Figma 캔버스 x좌표 기준):
+`default → monochrome-light → monochrome-dark → blue → cobalt → teal → green → olive → pink → navy → yellow → orange → red → purple`
+
+```
+xsmall × default          → 1729:2
+xsmall × monochrome-light → 1729:41
+xsmall × monochrome-dark  → 1729:38
+xsmall × blue             → 1729:5
+xsmall × cobalt           → 1729:8
+xsmall × teal             → 1729:11
+xsmall × green            → 1729:14
+xsmall × olive            → 1729:17
+xsmall × pink             → 1729:20
+xsmall × navy             → 1729:23
+xsmall × yellow           → 1729:26
+xsmall × orange           → 1729:29
+xsmall × red              → 1729:32
+xsmall × purple           → 1729:35
+
+small  × default          → 1729:44
+small  × monochrome-light → 1729:83
+small  × monochrome-dark  → 1729:80
+small  × blue             → 1729:47
+small  × cobalt           → 1729:50
+small  × teal             → 1729:53
+small  × green            → 1729:56
+small  × olive            → 1729:59
+small  × pink             → 1729:62
+small  × navy             → 1729:65
+small  × yellow           → 1729:68
+small  × orange           → 1729:71
+small  × red              → 1729:74
+small  × purple           → 1729:77
+
+medium × default          → 1729:86
+medium × monochrome-light → 1729:125
+medium × monochrome-dark  → 1729:122
+medium × blue             → 1729:89
+medium × cobalt           → 1729:92
+medium × teal             → 1729:95
+medium × green            → 1729:98
+medium × olive            → 1729:101
+medium × pink             → 1729:104
+medium × navy             → 1729:107
+medium × yellow           → 1729:110
+medium × orange           → 1729:113
+medium × red              → 1729:116
+medium × purple           → 1729:119
+
+large  × default          → 1729:128
+large  × monochrome-light → 1729:167
+large  × monochrome-dark  → 1729:164
+large  × blue             → 1729:131
+large  × cobalt           → 1729:134
+large  × teal             → 1729:137
+large  × green            → 1729:140
+large  × olive            → 1729:143
+large  × pink             → 1729:146
+large  × navy             → 1729:149
+large  × yellow           → 1729:152
+large  × orange           → 1729:155
+large  × red              → 1729:158
+large  × purple           → 1729:161
+```

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
 import io.channel.bezier.BezierTheme
+import io.channel.bezier.compose.sample.playground.BadgePlaygroundKey
+import io.channel.bezier.compose.sample.playground.BadgePlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ComponentListKey
@@ -50,6 +52,7 @@ private fun PlaygroundApp() {
                             ComponentListScreen(
                                     onSelectButton = { backStack.add(ButtonPlaygroundKey) },
                                     onSelectIconButton = { backStack.add(IconButtonPlaygroundKey) },
+                                    onSelectBadge = { backStack.add(BadgePlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -57,6 +60,9 @@ private fun PlaygroundApp() {
                         }
                         entry<IconButtonPlaygroundKey> {
                             IconButtonPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<BadgePlaygroundKey> {
+                            BadgePlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/BadgePlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/BadgePlaygroundScreen.kt
@@ -1,0 +1,84 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.v3.component.Badge
+import io.channel.bezier.v3.component.BadgeColor
+import io.channel.bezier.v3.component.BadgeSize
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun BadgePlaygroundScreen(onBack: () -> Unit) {
+    var size by remember { mutableStateOf(BadgeSize.Xsmall) }
+    var color by remember { mutableStateOf(BadgeColor.Default) }
+    var hasIcon by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Badge") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Badge(
+                        label = "Badge",
+                        size = size,
+                        color = color,
+                        iconSource = if (hasIcon) BezierIcons.Plus else null,
+                )
+            }
+
+            Divider()
+
+            EnumControl("Size", BadgeSize.values(), size) { size = it }
+            EnumControl("Color", BadgeColor.values(), color) { color = it }
+            BooleanControl("hasIcon", hasIcon) { hasIcon = it }
+        }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 fun ComponentListScreen(
         onSelectButton: () -> Unit,
         onSelectIconButton: () -> Unit,
+        onSelectBadge: () -> Unit,
 ) {
     Scaffold(
             topBar = { TopAppBar(title = { Text("v3 Components") }) },
@@ -30,6 +31,8 @@ fun ComponentListScreen(
             ComponentRow("Button", onClick = onSelectButton)
             Divider()
             ComponentRow("IconButton", onClick = onSelectIconButton)
+            Divider()
+            ComponentRow("Badge", onClick = onSelectBadge)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -5,3 +5,5 @@ data object ComponentListKey
 data object ButtonPlaygroundKey
 
 data object IconButtonPlaygroundKey
+
+data object BadgePlaygroundKey


### PR DESCRIPTION
## Summary

- Figma SSOT(node `1729:170`) 기반 Badge `SPEC.md` 작성
- `io.channel.bezier.v3.component.Badge` Compose 컴포넌트 신규 구현 (Size 4 × Color 14 = 56 variant, `hasIcon` 토글 슬롯)
- sample 플레이그라운드에 Badge 항목 추가

## SPEC 검증

Figma → SPEC → 구현 3단계 사이클 진행. SPEC 검증 7개 차원(Properties / Layout / Color / Typography / Asset / Noise / Reference) 모두 통과 후 구현. Compose Implementation Validator 재검증 통과.

주요 의도된 결정:
- `default` 색상은 icon이 text와 다른 토큰 사용 (`color/text/neutral/light` vs `color/text/neutral`) — Figma SSOT 그대로 분리 매핑
- `default` 와 `monochrome-light` 배경 동일 (`color/fill/neutral/light`) — 두 color 간 차이는 text/icon에서만 발생
- `medium`/`large` typography는 Custom raw (`fontSize`/`lineHeight`/`letterSpacing`을 개별 token으로 합성). Figma에 묶음 Typography style 미등록 → 디자이너 확인 필요한 회색 지대로 SPEC §4에 명시
- Badge는 읽기 전용. `clickable` 없음. 사용자가 제거할 수 있어야 하는 케이스는 Tag 사용

## Test plan

- [x] `:bezier:assembleDebug` 빌드 성공
- [x] `:sample:assembleDebug` 빌드 성공
- [x] 실기기(SM-S918N) 설치 확인
- [ ] sample 앱에서 BadgePlaygroundScreen 진입 후 4 size × 14 color × {no icon, with icon} 시각 확인
- [ ] dark mode preview 시각 확인
- [ ] Figma 캡처와 1:1 시각 비교 (xsmall/small/medium/large × 14 color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)