### PR TITLE
v3 패키지에 Tag 컴포넌트 신규 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ fabric.properties
 # End of https://www.toptal.com/developers/gitignore/api/android,gradle,androidstudio
 
 .DS_Store
+
+# 로컬 컴포넌트 spec 문서 (Figma SSOT 기반, 코드 리뷰 대상 아님)
+docs/

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
@@ -1,0 +1,219 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.color.BezierSemanticColorV3
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.CancelSmall
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+@Composable
+fun Tag(
+        label: String,
+        modifier: Modifier = Modifier,
+        size: TagSize = TagSize.Xsmall,
+        color: TagColor = TagColor.Default,
+        onDelete: (() -> Unit)? = null,
+) {
+    val colors = BezierTheme.colorsV3
+    val spec = size.spec
+
+    Row(
+            modifier = modifier
+                    .clip(RoundedCornerShape(TagCornerRadius))
+                    .background(color.background(colors))
+                    .padding(
+                            horizontal = spec.horizontalPadding,
+                            vertical = spec.verticalPadding,
+                    ),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+                modifier = Modifier.padding(horizontal = TagTextInnerHorizontalPadding),
+        ) {
+            TagLabel(text = label, size = size, color = colors.textNeutral)
+        }
+        if (onDelete != null) {
+            Box(
+                    modifier = Modifier
+                            .size(TagCancelIconLength)
+                            .clip(CircleShape)
+                            .clickable(onClick = onDelete),
+            ) {
+                Icon(
+                        imageVector = BezierIcons.CancelSmall.imageVector,
+                        contentDescription = null,
+                        tint = colors.textNeutralLight,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagLabel(text: String, size: TagSize, color: Color) {
+    when (size) {
+        TagSize.Xsmall -> BezierText(
+                text = text,
+                typo = BezierTypo.TextXSmall,
+                weight = BezierWeight.Regular,
+                color = color,
+        )
+
+        TagSize.Small -> BezierText(
+                text = text,
+                typo = BezierTypo.TextMedium,
+                weight = BezierWeight.Regular,
+                color = color,
+        )
+
+        TagSize.Medium -> Text(
+                text = text,
+                color = color,
+                fontSize = 15.sp,
+                lineHeight = 18.sp,
+                letterSpacing = (-0.1).sp,
+                fontWeight = FontWeight.Normal,
+        )
+
+        TagSize.Large -> Text(
+                text = text,
+                color = color,
+                fontSize = 16.sp,
+                lineHeight = 20.sp,
+                letterSpacing = (-0.1).sp,
+                fontWeight = FontWeight.Normal,
+        )
+    }
+}
+
+private val TagCancelIconLength: Dp = 16.dp
+private val TagTextInnerHorizontalPadding: Dp = 4.dp
+private val TagCornerRadius: Dp = 32.dp
+
+enum class TagSize {
+    Xsmall,
+    Small,
+    Medium,
+    Large;
+
+    internal val spec: TagLayoutSpec
+        get() = when (this) {
+            Xsmall -> TagLayoutSpec(horizontalPadding = 4.dp, verticalPadding = 1.dp)
+            Small -> TagLayoutSpec(horizontalPadding = 4.dp, verticalPadding = 2.dp)
+            Medium -> TagLayoutSpec(horizontalPadding = 4.dp, verticalPadding = 2.dp)
+            Large -> TagLayoutSpec(horizontalPadding = 4.dp, verticalPadding = 3.dp)
+        }
+}
+
+enum class TagColor {
+    Default,
+    Red,
+    Orange,
+    Yellow,
+    Olive,
+    Green,
+    Teal,
+    Cobalt,
+    Blue,
+    Purple,
+    Pink,
+    Navy;
+
+    @Composable
+    internal fun background(colors: BezierSemanticColorV3): Color = when (this) {
+        Default -> colors.fillNeutralLight
+        Red -> colors.fillAccentRedHeavy
+        Orange -> colors.fillAccentOrangeHeavy
+        Yellow -> colors.fillAccentYellowHeavy
+        Olive -> colors.fillAccentOliveHeavy
+        Green -> colors.fillAccentGreenHeavy
+        Teal -> colors.fillAccentTealHeavy
+        Cobalt -> colors.fillAccentCobaltHeavy
+        Blue -> colors.fillAccentBlueHeavy
+        Purple -> colors.fillAccentPurpleHeavy
+        Pink -> colors.fillAccentPinkHeavy
+        Navy -> colors.fillAccentNavyHeavy
+    }
+}
+
+internal data class TagLayoutSpec(
+        val horizontalPadding: Dp,
+        val verticalPadding: Dp,
+)
+
+@Composable
+private fun TagMatrix(onDelete: Boolean) {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            TagSize.entries.forEach { size ->
+                Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Box(
+                            modifier = Modifier.size(width = 64.dp, height = 26.dp),
+                            contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BezierText(
+                                text = size.name.lowercase(),
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                    TagColor.entries.forEach { color ->
+                        Tag(
+                                label = "Tag",
+                                size = size,
+                                color = color,
+                                onDelete = if (onDelete) ({}) else null,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 1100)
+@Composable
+private fun TagMatrixPreview() = TagMatrix(onDelete = false)
+
+@Preview(showBackground = true, widthDp = 1100)
+@Composable
+private fun TagMatrixOnDeletePreview() = TagMatrix(onDelete = true)
+
+@Preview(showBackground = true, widthDp = 1100)
+@Preview(showBackground = true, widthDp = 1100, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun TagMatrixDarkPreview() = TagMatrix(onDelete = true)

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -23,6 +23,8 @@ import io.channel.bezier.compose.sample.playground.ComponentListKey
 import io.channel.bezier.compose.sample.playground.ComponentListScreen
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.TagPlaygroundKey
+import io.channel.bezier.compose.sample.playground.TagPlaygroundScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,7 +46,7 @@ private fun PlaygroundApp() {
         ) {
             val backStack = remember { mutableStateListOf<Any>(ComponentListKey) }
             NavDisplay(
-                    modifier = Modifier.systemBarsPadding(),
+                    modifier = Modifier.statusBarsPadding(),
                     backStack = backStack,
                     onBack = { backStack.removeLastOrNull() },
                     entryProvider = entryProvider {
@@ -53,6 +55,7 @@ private fun PlaygroundApp() {
                                     onSelectButton = { backStack.add(ButtonPlaygroundKey) },
                                     onSelectIconButton = { backStack.add(IconButtonPlaygroundKey) },
                                     onSelectBadge = { backStack.add(BadgePlaygroundKey) },
+                                    onSelectTag = { backStack.add(TagPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -63,6 +66,9 @@ private fun PlaygroundApp() {
                         }
                         entry<BadgePlaygroundKey> {
                             BadgePlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<TagPlaygroundKey> {
+                            TagPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -19,9 +20,15 @@ fun ComponentListScreen(
         onSelectButton: () -> Unit,
         onSelectIconButton: () -> Unit,
         onSelectBadge: () -> Unit,
+        onSelectTag: () -> Unit,
 ) {
     Scaffold(
-            topBar = { TopAppBar(title = { Text("v3 Components") }) },
+            topBar = {
+                TopAppBar(
+                        modifier = Modifier.statusBarsPadding(),
+                        title = { Text("v3 Components") },
+                )
+            },
     ) { padding ->
         Column(
                 modifier = Modifier
@@ -33,6 +40,8 @@ fun ComponentListScreen(
             ComponentRow("IconButton", onClick = onSelectIconButton)
             Divider()
             ComponentRow("Badge", onClick = onSelectBadge)
+            Divider()
+            ComponentRow("Tag", onClick = onSelectTag)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -1,9 +1,7 @@
 package io.channel.bezier.compose.sample.playground
 
 data object ComponentListKey
-
 data object ButtonPlaygroundKey
-
 data object IconButtonPlaygroundKey
-
 data object BadgePlaygroundKey
+data object TagPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/TagPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/TagPlaygroundScreen.kt
@@ -1,0 +1,83 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.Tag
+import io.channel.bezier.v3.component.TagColor
+import io.channel.bezier.v3.component.TagSize
+
+@Composable
+fun TagPlaygroundScreen(onBack: () -> Unit) {
+    var size by remember { mutableStateOf(TagSize.Xsmall) }
+    var color by remember { mutableStateOf(TagColor.Default) }
+    var onDelete by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Tag") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Tag(
+                        label = "Tag",
+                        size = size,
+                        color = color,
+                        onDelete = if (onDelete) ({}) else null,
+                )
+            }
+
+            Divider()
+
+            EnumControl("Size", TagSize.values(), size) { size = it }
+            EnumControl("Color", TagColor.values(), color) { color = it }
+            BooleanControl("onDelete", onDelete) { onDelete = it }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Figma SSOT(node 1730:122) 기반으로 `io.channel.bezier.v3.component.Tag` 신규 추가
- `TagSize` 4종(xsmall/small/medium/large) × `TagColor` 12종(default + 11 accent), `onDelete` boolean property 지원
- 텍스트 색상은 모든 variant 공통 `textNeutral`, cancel-small 아이콘 색상은 `textNeutralLight`로 토큰 분리
- 로컬 spec 문서 보관 경로(`docs/`)를 `.gitignore`에 추가
- sample 모듈 playground에 Tag 진입점 추가 (Size / Color / onDelete 컨트롤)
- `NavDisplay`에 `Modifier.statusBarsPadding()` 적용해 edge-to-edge에서 TopAppBar가 status bar 침범하지 않도록 처리

## Test plan
- [ ] `:bezier:assembleDebug` 빌드 성공
- [ ] `:sample:installDebug` 후 실기기에서 ComponentList → Tag 진입 정상
- [ ] Size / Color 라디오 선택 시 즉시 반영 (4 × 12 variant 모두 렌더)
- [ ] onDelete 토글 시 cancel-small 아이콘 노출/숨김 확인
- [ ] 다크 모드 색상 토큰 정상 적용
- [ ] TopAppBar가 status bar에 가려지지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)