### PR TITLE
v3 패키지에 Avatar, AvatarStatus, AvatarGroup 컴포넌트 신규 추가

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Avatar.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Avatar.kt
@@ -1,0 +1,196 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.shape.SmoothRoundedCornerShape
+import io.channel.bezier.typography.BezierTypo
+
+private const val AvatarRadiusFraction = 42
+
+@Composable
+fun Avatar(
+        image: Painter,
+        modifier: Modifier = Modifier,
+        size: AvatarSize = AvatarSize.Size16,
+        enabled: Boolean = true,
+        showBorder: Boolean = false,
+        status: AvatarStatusType? = null,
+        contentDescription: String? = null,
+) {
+    val layout = size.layout
+    val shape = SmoothRoundedCornerShape(percent = AvatarRadiusFraction)
+    val containerAlpha = if (enabled) 1f else AvatarDisabledOpacity
+
+    val borderModifier = if (showBorder) {
+        Modifier.outsideBorder(
+                color = BezierTheme.colorsV3.surface,
+                borderWidth = layout.borderWidth,
+                shape = shape,
+        )
+    } else {
+        Modifier
+    }
+
+    Box(
+            modifier = modifier
+                    .size(layout.length)
+                    .then(borderModifier)
+                    .graphicsLayer(alpha = containerAlpha),
+    ) {
+        Image(
+                modifier = Modifier
+                        .size(layout.length)
+                        .clip(shape),
+                painter = image,
+                contentDescription = contentDescription,
+                contentScale = ContentScale.Crop,
+        )
+
+        if (status != null) {
+            AvatarStatus(
+                    type = status,
+                    size = layout.statusSize,
+                    modifier = Modifier.offset(x = layout.statusOffsetX, y = layout.statusOffsetY),
+            )
+        }
+    }
+}
+
+private fun Modifier.outsideBorder(
+        color: Color,
+        borderWidth: Dp,
+        shape: Shape,
+) = drawBehind {
+    val borderWidthPx = borderWidth.toPx()
+    val grownSize = Size(
+            width = size.width + borderWidthPx * 2,
+            height = size.height + borderWidthPx * 2,
+    )
+    val outline = shape.createOutline(grownSize, layoutDirection, this)
+    translate(left = -borderWidthPx, top = -borderWidthPx) {
+        drawOutline(outline = outline, color = color)
+    }
+}
+
+private const val AvatarDisabledOpacity = 0.4f
+
+enum class AvatarSize {
+    Size16,
+    Size20,
+    Size24,
+    Size30,
+    Size36,
+    Size42,
+    Size48,
+    Size72,
+    Size90,
+    Size120,
+    Size160;
+
+    internal val layout: AvatarLayoutSpec
+        get() = when (this) {
+            Size16 -> AvatarLayoutSpec(16.dp, 1.dp, AvatarStatusSize.Small, 12.dp, 12.dp)
+            Size20 -> AvatarLayoutSpec(20.dp, 1.dp, AvatarStatusSize.Small, 14.dp, 14.dp)
+            Size24 -> AvatarLayoutSpec(24.dp, 1.5.dp, AvatarStatusSize.Small, 18.dp, 18.dp)
+            Size30 -> AvatarLayoutSpec(30.dp, 1.5.dp, AvatarStatusSize.Medium, 21.dp, 20.dp)
+            Size36 -> AvatarLayoutSpec(36.dp, 1.5.dp, AvatarStatusSize.Medium, 26.dp, 26.dp)
+            Size42 -> AvatarLayoutSpec(42.dp, 2.dp, AvatarStatusSize.Medium, 32.dp, 32.dp)
+            Size48 -> AvatarLayoutSpec(48.dp, 2.dp, AvatarStatusSize.Medium, 36.dp, 37.dp)
+            Size72 -> AvatarLayoutSpec(72.dp, 2.5.dp, AvatarStatusSize.Large, 55.dp, 54.dp)
+            Size90 -> AvatarLayoutSpec(90.dp, 3.dp, AvatarStatusSize.XLarge, 68.dp, 68.dp)
+            Size120 -> AvatarLayoutSpec(120.dp, 3.5.dp, AvatarStatusSize.XLarge, 96.dp, 94.dp)
+            Size160 -> AvatarLayoutSpec(160.dp, 4.dp, AvatarStatusSize.XLarge, 132.dp, 129.dp)
+        }
+}
+
+internal data class AvatarLayoutSpec(
+        val length: Dp,
+        val borderWidth: Dp,
+        val statusSize: AvatarStatusSize,
+        val statusOffsetX: Dp,
+        val statusOffsetY: Dp,
+)
+
+@Composable
+private fun AvatarMatrix(
+        enabled: Boolean,
+        showBorder: Boolean,
+        status: AvatarStatusType?,
+) {
+    val previewImage = ColorPainter(Color(0xFFB6CED6))
+
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            AvatarSize.entries.forEach { size ->
+                Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Box(modifier = Modifier.size(width = 64.dp, height = 24.dp), contentAlignment = Alignment.CenterStart) {
+                        BezierText(
+                                text = size.name.removePrefix("Size"),
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                    Avatar(
+                            image = previewImage,
+                            size = size,
+                            enabled = enabled,
+                            showBorder = showBorder,
+                            status = status,
+                            contentDescription = "preview",
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 320, heightDp = 1200)
+@Composable
+private fun AvatarMatrixDefaultPreview() = AvatarMatrix(enabled = true, showBorder = false, status = null)
+
+@Preview(showBackground = true, widthDp = 320, heightDp = 1200)
+@Composable
+private fun AvatarMatrixDisabledPreview() = AvatarMatrix(enabled = false, showBorder = false, status = null)
+
+@Preview(showBackground = true, widthDp = 320, heightDp = 1200)
+@Composable
+private fun AvatarMatrixBorderStatusPreview() = AvatarMatrix(enabled = true, showBorder = true, status = AvatarStatusType.Online)
+
+@Preview(showBackground = true, widthDp = 320, heightDp = 1200, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AvatarMatrixDarkPreview() = AvatarMatrix(enabled = true, showBorder = true, status = AvatarStatusType.OnlineDnd)

--- a/bezier/src/main/java/io/channel/bezier/v3/component/AvatarGroup.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/AvatarGroup.kt
@@ -1,0 +1,203 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.More
+import io.channel.bezier.shape.SmoothRoundedCornerShape
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+private const val AvatarGroupShapePercent = 42
+private val AvatarGroupCountEllipsisGap: Dp = 4.dp
+private val Size20CountTextPadding: Dp = 4.dp
+
+@Composable
+fun AvatarGroup(
+        avatars: List<Painter>,
+        modifier: Modifier = Modifier,
+        size: AvatarGroupSize = AvatarGroupSize.Size20,
+        ellipsisType: AvatarGroupEllipsisType = AvatarGroupEllipsisType.Icon,
+) {
+    val layout = size.layout(ellipsisType)
+    val hasEllipsis = avatars.size > 3
+    val visibleAvatars = if (hasEllipsis) avatars.take(3) else avatars
+    val shape = SmoothRoundedCornerShape(percent = AvatarGroupShapePercent)
+    val moreText = "+${avatars.size - 3}"
+
+    Box(modifier = modifier) {
+        visibleAvatars.forEachIndexed { idx, painter ->
+            Avatar(
+                    image = painter,
+                    size = layout.avatarSize,
+                    modifier = Modifier.offset(x = layout.spacing * idx),
+            )
+        }
+
+        if (hasEllipsis) {
+            when (ellipsisType) {
+                AvatarGroupEllipsisType.Icon -> EllipsisIcon(
+                        avatarPainter = avatars[3],
+                        size = layout.avatarSize,
+                        avatarLength = layout.avatarLength,
+                        moreIconSize = layout.moreIconSize,
+                        shape = shape,
+                        modifier = Modifier.offset(x = layout.spacing * 3),
+                )
+
+                AvatarGroupEllipsisType.Count -> {
+                    val textOffsetX = layout.spacing * 2 + layout.avatarLength + AvatarGroupCountEllipsisGap
+                    Box(
+                            modifier = Modifier
+                                    .offset(x = textOffsetX)
+                                    .height(layout.avatarLength)
+                                    .padding(horizontal = layout.countTextHorizontalPadding),
+                            contentAlignment = Alignment.Center,
+                    ) {
+                        BezierText(
+                                text = moreText,
+                                typo = layout.countTypo,
+                                weight = BezierWeight.Bold,
+                                color = BezierTheme.colorsV3.textNeutralLighter,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EllipsisIcon(
+        avatarPainter: Painter,
+        size: AvatarSize,
+        avatarLength: Dp,
+        moreIconSize: Dp,
+        shape: androidx.compose.ui.graphics.Shape,
+        modifier: Modifier,
+) {
+    Box(modifier = modifier) {
+        Avatar(
+                image = avatarPainter,
+                size = size,
+                showBorder = true,
+        )
+        Box(
+                modifier = Modifier
+                        .size(avatarLength)
+                        .clip(shape)
+                        .background(BezierTheme.colorsV3.dimAbsoluteBlack),
+                contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                    imageVector = BezierIcons.More.imageVector,
+                    contentDescription = null,
+                    modifier = Modifier.size(moreIconSize),
+                    tint = BezierTheme.colorsV3.iconAbsoluteWhite,
+            )
+        }
+    }
+}
+
+enum class AvatarGroupSize {
+    Size20,
+    Size24;
+
+    internal fun layout(ellipsisType: AvatarGroupEllipsisType): AvatarGroupLayoutSpec = when (this) {
+        Size20 -> AvatarGroupLayoutSpec(
+                avatarSize = AvatarSize.Size20,
+                avatarLength = 20.dp,
+                spacing = 13.dp,
+                moreIconSize = 12.dp,
+                countTypo = BezierTypo.TextXSmall,
+                countTextHorizontalPadding = Size20CountTextPadding,
+        )
+
+        Size24 -> AvatarGroupLayoutSpec(
+                avatarSize = AvatarSize.Size24,
+                avatarLength = 24.dp,
+                spacing = 17.dp,
+                moreIconSize = 16.dp,
+                countTypo = BezierTypo.TextSmall,
+                countTextHorizontalPadding = 0.dp,
+        )
+    }
+}
+
+enum class AvatarGroupEllipsisType {
+    Icon,
+    Count,
+}
+
+internal data class AvatarGroupLayoutSpec(
+        val avatarSize: AvatarSize,
+        val avatarLength: Dp,
+        val spacing: Dp,
+        val moreIconSize: Dp,
+        val countTypo: BezierTypo,
+        val countTextHorizontalPadding: Dp,
+)
+
+@Composable
+private fun AvatarGroupMatrix() {
+    val previewPainters: List<Painter> = listOf(
+            ColorPainter(Color(0xFFB6CED6)),
+            ColorPainter(Color(0xFFD6BFB6)),
+            ColorPainter(Color(0xFFB6D6BF)),
+            ColorPainter(Color(0xFFCFB6D6)),
+            ColorPainter(Color(0xFFD6CCB6)),
+    )
+
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            listOf(AvatarGroupSize.Size20, AvatarGroupSize.Size24).forEach { size ->
+                listOf(AvatarGroupEllipsisType.Icon, AvatarGroupEllipsisType.Count).forEach { ellipsisType ->
+                    Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        AvatarGroup(
+                                avatars = previewPainters,
+                                size = size,
+                                ellipsisType = ellipsisType,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 320)
+@Composable
+private fun AvatarGroupMatrixPreview() = AvatarGroupMatrix()
+
+@Preview(showBackground = true, widthDp = 320, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AvatarGroupMatrixDarkPreview() = AvatarGroupMatrix()

--- a/bezier/src/main/java/io/channel/bezier/v3/component/AvatarStatus.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/AvatarStatus.kt
@@ -1,0 +1,127 @@
+package io.channel.bezier.v3.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.color.BezierSemanticColorV3
+import io.channel.bezier.icon.Lock
+import io.channel.bezier.icon.MoonFilled
+
+@Composable
+internal fun AvatarStatus(
+        type: AvatarStatusType,
+        size: AvatarStatusSize,
+        modifier: Modifier = Modifier,
+) {
+    val colors = BezierTheme.colorsV3
+    val layout = size.layout
+    val innerColor = type.innerColor(colors)
+
+    Box(
+            modifier = modifier
+                    .size(layout.container)
+                    .clip(RoundedCornerShape(layout.cornerRadius))
+                    .background(colors.surfaceHighest)
+                    .padding(layout.padding),
+            contentAlignment = Alignment.Center,
+    ) {
+        when (type) {
+            AvatarStatusType.Online,
+            AvatarStatusType.Offline -> Box(
+                    modifier = Modifier
+                            .size(layout.inner)
+                            .clip(CircleShape)
+                            .background(innerColor),
+            )
+
+            AvatarStatusType.Lock -> Icon(
+                    modifier = Modifier.size(layout.inner),
+                    imageVector = BezierIcons.Lock.imageVector,
+                    tint = innerColor,
+                    contentDescription = null,
+            )
+
+            AvatarStatusType.OnlineDnd, AvatarStatusType.OfflineDnd -> Icon(
+                    modifier = Modifier.size(layout.inner),
+                    imageVector = BezierIcons.MoonFilled.imageVector,
+                    tint = innerColor,
+                    contentDescription = null,
+            )
+        }
+    }
+}
+
+enum class AvatarStatusType {
+    Online,
+    Offline,
+    Lock,
+    OnlineDnd,
+    OfflineDnd;
+
+    @Composable
+    internal fun innerColor(colors: BezierSemanticColorV3): Color = when (this) {
+        Online -> colors.iconAccentGreen
+        Offline -> colors.iconNeutral
+        Lock -> colors.iconNeutral
+        OnlineDnd -> colors.iconAccentGreen
+        OfflineDnd -> colors.iconAccentYellow
+    }
+}
+
+internal enum class AvatarStatusSize {
+    Small,
+    Medium,
+    Large,
+    XLarge;
+
+    internal val layout: AvatarStatusLayoutSpec
+        get() = when (this) {
+            Small -> AvatarStatusLayoutSpec(
+                    container = 8.dp,
+                    padding = 2.dp,
+                    inner = 6.dp,
+                    cornerRadius = 4.dp,
+            )
+
+            Medium -> AvatarStatusLayoutSpec(
+                    container = 12.dp,
+                    padding = 2.dp,
+                    inner = 8.dp,
+                    cornerRadius = 6.dp,
+            )
+
+            Large -> AvatarStatusLayoutSpec(
+                    container = 16.dp,
+                    padding = 3.dp,
+                    inner = 12.dp,
+                    cornerRadius = 8.dp,
+            )
+
+            XLarge -> AvatarStatusLayoutSpec(
+                    container = 24.dp,
+                    padding = 2.dp,
+                    inner = 18.dp,
+                    cornerRadius = 12.dp,
+            )
+        }
+}
+
+internal data class AvatarStatusLayoutSpec(
+        val container: Dp,
+        val padding: Dp,
+        val inner: Dp,
+        val cornerRadius: Dp,
+)

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -15,6 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
 import io.channel.bezier.BezierTheme
+import io.channel.bezier.compose.sample.playground.AvatarGroupPlaygroundKey
+import io.channel.bezier.compose.sample.playground.AvatarGroupPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.AvatarPlaygroundKey
+import io.channel.bezier.compose.sample.playground.AvatarPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.BadgePlaygroundKey
 import io.channel.bezier.compose.sample.playground.BadgePlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundKey
@@ -56,6 +60,8 @@ private fun PlaygroundApp() {
                                     onSelectIconButton = { backStack.add(IconButtonPlaygroundKey) },
                                     onSelectBadge = { backStack.add(BadgePlaygroundKey) },
                                     onSelectTag = { backStack.add(TagPlaygroundKey) },
+                                    onSelectAvatar = { backStack.add(AvatarPlaygroundKey) },
+                                    onSelectAvatarGroup = { backStack.add(AvatarGroupPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -69,6 +75,12 @@ private fun PlaygroundApp() {
                         }
                         entry<TagPlaygroundKey> {
                             TagPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<AvatarPlaygroundKey> {
+                            AvatarPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<AvatarGroupPlaygroundKey> {
+                            AvatarGroupPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/AvatarGroupPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/AvatarGroupPlaygroundScreen.kt
@@ -1,0 +1,107 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.AvatarGroup
+import io.channel.bezier.v3.component.AvatarGroupEllipsisType
+import io.channel.bezier.v3.component.AvatarGroupSize
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import androidx.compose.runtime.setValue
+
+@Composable
+fun AvatarGroupPlaygroundScreen(onBack: () -> Unit) {
+    var size by remember { mutableStateOf(AvatarGroupSize.Size24) }
+    var ellipsisType by remember { mutableStateOf(AvatarGroupEllipsisType.Icon) }
+    var countOption by remember { mutableStateOf(AvatarCountOption.Five) }
+
+    val palette: List<Painter> = remember {
+        listOf(
+                ColorPainter(Color(0xFFB6CED6)),
+                ColorPainter(Color(0xFFD6BFB6)),
+                ColorPainter(Color(0xFFB6D6BF)),
+                ColorPainter(Color(0xFFCFB6D6)),
+                ColorPainter(Color(0xFFD6CCB6)),
+                ColorPainter(Color(0xFFB6B6D6)),
+                ColorPainter(Color(0xFFD6B6C2)),
+                ColorPainter(Color(0xFFC2D6B6)),
+        )
+    }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("AvatarGroup") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                AvatarGroup(
+                        avatars = palette.take(countOption.count),
+                        size = size,
+                        ellipsisType = ellipsisType,
+                )
+            }
+
+            Divider()
+
+            EnumControl("Size", AvatarGroupSize.values(), size) { size = it }
+            EnumControl("EllipsisType", AvatarGroupEllipsisType.values(), ellipsisType) { ellipsisType = it }
+            EnumControl("Avatars count", AvatarCountOption.values(), countOption) { countOption = it }
+        }
+    }
+}
+
+enum class AvatarCountOption(val count: Int) {
+    One(1),
+    Two(2),
+    Three(3),
+    Four(4),
+    Five(5),
+    Eight(8),
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/AvatarPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/AvatarPlaygroundScreen.kt
@@ -1,0 +1,93 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.Avatar
+import io.channel.bezier.v3.component.AvatarSize
+import io.channel.bezier.v3.component.AvatarStatusType
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun AvatarPlaygroundScreen(onBack: () -> Unit) {
+    var size by remember { mutableStateOf(AvatarSize.Size48) }
+    var enabled by remember { mutableStateOf(true) }
+    var showBorder by remember { mutableStateOf(false) }
+    var showStatus by remember { mutableStateOf(false) }
+    var statusType by remember { mutableStateOf(AvatarStatusType.Online) }
+
+    val previewPainter = remember { ColorPainter(Color(0xFFB6CED6)) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Avatar") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Avatar(
+                        image = previewPainter,
+                        size = size,
+                        enabled = enabled,
+                        showBorder = showBorder,
+                        status = if (showStatus) statusType else null,
+                        contentDescription = "preview",
+                )
+            }
+
+            Divider()
+
+            EnumControl("Size", AvatarSize.values(), size) { size = it }
+            BooleanControl("enabled", enabled) { enabled = it }
+            BooleanControl("showBorder", showBorder) { showBorder = it }
+            BooleanControl("showStatus", showStatus) { showStatus = it }
+            EnumControl("statusType", AvatarStatusType.values(), statusType) { statusType = it }
+        }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -21,6 +21,8 @@ fun ComponentListScreen(
         onSelectIconButton: () -> Unit,
         onSelectBadge: () -> Unit,
         onSelectTag: () -> Unit,
+        onSelectAvatar: () -> Unit,
+        onSelectAvatarGroup: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -42,6 +44,10 @@ fun ComponentListScreen(
             ComponentRow("Badge", onClick = onSelectBadge)
             Divider()
             ComponentRow("Tag", onClick = onSelectTag)
+            Divider()
+            ComponentRow("Avatar", onClick = onSelectAvatar)
+            Divider()
+            ComponentRow("AvatarGroup", onClick = onSelectAvatarGroup)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -5,3 +5,5 @@ data object ButtonPlaygroundKey
 data object IconButtonPlaygroundKey
 data object BadgePlaygroundKey
 data object TagPlaygroundKey
+data object AvatarPlaygroundKey
+data object AvatarGroupPlaygroundKey


### PR DESCRIPTION
## Summary
- v3 패키지에 `Avatar` / `AvatarStatus` (internal) / `AvatarGroup` 컴포넌트 신규 추가
- 11 size × 2 state × showBorder × status (`AvatarStatusType?`) Avatar 컴포넌트
- 5 type × 4 size internal AvatarStatus (Avatar 내부 전용)
- 2 size × 2 ellipsisType AvatarGroup (`avatars: List<Painter>`, 4개 초과 시 ellipsis)
- sample playground에 Avatar / AvatarGroup 추가

## Test plan
- [ ] Avatar 11 size × showBorder 토글로 외곽 띠 시각 확인
- [ ] Avatar status 5개 type 모두 확인 (Online / Offline / Lock / OnlineDnd / OfflineDnd)
- [ ] Avatar disabled 시 컨테이너 전체 opacity 0.4 적용
- [ ] AvatarGroup 4 variants (size 20/24 × ellipsisType icon/count) 확인
- [ ] AvatarGroup avatars 3개 이하면 ellipsis 미표시, 4개 이상이면 앞 3개 + ellipsis
- [ ] dark mode 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)