### PR TITLE
sample 앱 Firebase App Distribution 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -1,0 +1,69 @@
+name: Deploy to Firebase App Distribution
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: '릴리즈 노트 (비워두면 마지막 커밋 메시지를 사용)'
+        required: false
+        type: string
+
+env:
+  APPLICATION_ID: io.channel.bezier.compose.sample
+  # Firebase 콘솔 > App Distribution > 테스터 및 그룹의 그룹 별칭(alias). 여러 그룹은 콤마로 구분.
+  TESTER_GROUPS: channel
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Restore google-services.json from secret
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > sample/google-services.json
+
+      - name: Build debug APK
+        run: ./gradlew :sample:assembleDebug
+
+      - name: Extract Firebase App ID from google-services.json
+        id: appid
+        run: |
+          APP_ID=$(jq -r --arg pkg "$APPLICATION_ID" \
+            '.client[] | select(.client_info.android_client_info.package_name==$pkg) | .client_info.mobilesdk_app_id' \
+            sample/google-services.json)
+          if [ -z "$APP_ID" ] || [ "$APP_ID" = "null" ]; then
+            echo "::error::google-services.json 에서 App ID를 찾지 못했습니다 (package: $APPLICATION_ID)"
+            exit 1
+          fi
+          echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve release notes
+        env:
+          INPUT_NOTES: ${{ github.event.inputs.release_notes }}
+        run: |
+          if [ -n "$INPUT_NOTES" ]; then
+            printf '%s' "$INPUT_NOTES" > release_notes.txt
+          else
+            git log -1 --pretty=%B > release_notes.txt
+          fi
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Distribute to Firebase App Distribution
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_APP_DISTRIBUTION_CREDENTIAL }}
+        run: |
+          firebase appdistribution:distribute \
+            sample/build/outputs/apk/debug/sample-debug.apk \
+            --app "${{ steps.appid.outputs.app_id }}" \
+            --groups "$TESTER_GROUPS" \
+            --release-notes-file release_notes.txt


### PR DESCRIPTION
## 개요
`:sample` 앱을 Firebase App Distribution에 배포하는 GitHub Actions 워크플로우를 추가합니다.

## 동작
- **자동 트리거**: `main` 브랜치 push(머지) 시
- **수동 트리거**: `workflow_dispatch` (Run workflow에서 브랜치 선택 + 릴리즈 노트 입력 가능)
- 순서: JDK 17 셋업 → `google-services.json` 복원 → `:sample:assembleDebug` → App ID 추출 → 릴리즈 노트 결정 → `firebase appdistribution:distribute`
- 배포 대상 테스터 그룹: `channel`
- 빌드 타입: **debug** (서명 설정 없음)
- 릴리즈 노트: 수동 입력값이 있으면 사용, 없으면 마지막 커밋 메시지

## 필요한 GitHub Secrets (등록 완료)
- `GOOGLE_SERVICES_JSON` — `google-services.json`을 base64 인코딩한 값. CI에서 복원해 App ID 추출에만 사용 (레포에는 커밋하지 않음, 이미 `.gitignore` 처리됨)
- `FIREBASE_APP_DISTRIBUTION_CREDENTIAL` — `firebase login:ci`로 발급한 토큰. `FIREBASE_TOKEN` 환경변수로 전달

## 설계 메모
- `:sample` 앱에 Firebase SDK 의존성이 없어 `google-services` Gradle 플러그인은 적용하지 않았습니다. `google-services.json`은 빌드용이 아니라 **App ID 추출용**으로만 CI에서 복원합니다. 따라서 `build.gradle.kts`는 변경하지 않았습니다.

## 검증 상태
- ✅ 로컬 `:sample:assembleDebug` 빌드 성공, APK 경로(`sample/build/outputs/apk/debug/sample-debug.apk`) 확인
- ✅ 워크플로우 YAML 문법 검증
- ⚠️ 실제 배포 동작(토큰 인증 → 그룹 전송)은 CI 첫 실행에서 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)