### PR TITLE
v3 Button label typography 토큰 정렬 및 leading/trailingContent 네이밍 변경

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/typography/BezierTypography.kt
+++ b/bezier/src/main/java/io/channel/bezier/typography/BezierTypography.kt
@@ -40,9 +40,9 @@ enum class BezierTypo(
     TextXXSmall(fontSize = BezierFontSize.Size11, lineHeight = BezierLineHeight.Size16, letterSpacing = BezierLetterSpacing.Normal),
 
     // Label (fixed Bold)
-    LabelLarge(fontSize = BezierFontSize.Size14, lineHeight = BezierLineHeight.Size18, letterSpacing = BezierLetterSpacing.Normal, fixedWeight = FontWeight.Bold),
-    LabelMedium(fontSize = BezierFontSize.Size13, lineHeight = BezierLineHeight.Size18, letterSpacing = BezierLetterSpacing.Normal, fixedWeight = FontWeight.Bold),
-    LabelSmall(fontSize = BezierFontSize.Size12, lineHeight = BezierLineHeight.Size16, letterSpacing = BezierLetterSpacing.Normal, fixedWeight = FontWeight.Bold),
+    LabelLarge(fontSize = BezierFontSize.Size15, lineHeight = BezierLineHeight.Size20, letterSpacing = BezierLetterSpacing.Normal, fixedWeight = FontWeight.Bold),
+    LabelMedium(fontSize = BezierFontSize.Size14, lineHeight = BezierLineHeight.Size20, letterSpacing = BezierLetterSpacing.Normal, fixedWeight = FontWeight.Bold),
+    LabelSmall(fontSize = BezierFontSize.Size13, lineHeight = BezierLineHeight.Size18, letterSpacing = BezierLetterSpacing.Normal, fixedWeight = FontWeight.Bold),
 
     // Caption (weight param supported)
     CaptionMedium(fontSize = BezierFontSize.Size12, lineHeight = BezierLineHeight.Size16, letterSpacing = BezierLetterSpacing.Normal),

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
@@ -51,8 +51,8 @@ fun Button(
         isActive: Boolean = false,
         isLoading: Boolean = false,
         enabled: Boolean = true,
-        leadingIcon: BezierIcon? = null,
-        trailingIcon: BezierIcon? = null,
+        leadingContent: BezierIcon? = null,
+        trailingContent: BezierIcon? = null,
         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
 
@@ -94,10 +94,10 @@ fun Button(
                 horizontalArrangement = Arrangement.spacedBy(spec.gap),
                 verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (leadingIcon != null) {
+            if (leadingContent != null) {
                 Icon(
                         modifier = Modifier.size(ButtonIconLength),
-                        imageVector = leadingIcon.imageVector,
+                        imageVector = leadingContent.imageVector,
                         tint = colorSpec.iconColor,
                         contentDescription = null,
                 )
@@ -112,10 +112,10 @@ fun Button(
                         color = colorSpec.textColor,
                 )
             }
-            if (trailingIcon != null) {
+            if (trailingContent != null) {
                 Icon(
                         modifier = Modifier.size(ButtonIconLength),
-                        imageVector = trailingIcon.imageVector,
+                        imageVector = trailingContent.imageVector,
                         tint = colorSpec.iconColor,
                         contentDescription = null,
                 )
@@ -188,9 +188,9 @@ enum class ButtonSize {
 
     internal val typo: BezierTypo
         get() = when (this) {
-            Xsmall -> BezierTypo.TextSmall
-            Small -> BezierTypo.TextMedium
-            Medium -> BezierTypo.TextLarge
+            Xsmall -> BezierTypo.LabelSmall
+            Small -> BezierTypo.LabelMedium
+            Medium -> BezierTypo.LabelLarge
             Large -> BezierTypo.TextXLarge
             Xlarge -> BezierTypo.TextXLarge
         }
@@ -389,8 +389,8 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
                                     size = size,
                                     variant = variant,
                                     semantic = semantic,
-                                    leadingIcon = BezierIcons.Plus,
-                                    trailingIcon = BezierIcons.Plus,
+                                    leadingContent = BezierIcons.Plus,
+                                    trailingContent = BezierIcons.Plus,
                             )
                         }
                         ButtonStateCell(cellWidth) {
@@ -400,8 +400,8 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
                                     size = size,
                                     variant = variant,
                                     semantic = semantic,
-                                    leadingIcon = BezierIcons.Plus,
-                                    trailingIcon = BezierIcons.Plus,
+                                    leadingContent = BezierIcons.Plus,
+                                    trailingContent = BezierIcons.Plus,
                                     interactionSource = pressedInteractionSource(),
                             )
                         }
@@ -412,8 +412,8 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
                                     size = size,
                                     variant = variant,
                                     semantic = semantic,
-                                    leadingIcon = BezierIcons.Plus,
-                                    trailingIcon = BezierIcons.Plus,
+                                    leadingContent = BezierIcons.Plus,
+                                    trailingContent = BezierIcons.Plus,
                                     isActive = true,
                             )
                         }
@@ -424,8 +424,8 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
                                     size = size,
                                     variant = variant,
                                     semantic = semantic,
-                                    leadingIcon = BezierIcons.Plus,
-                                    trailingIcon = BezierIcons.Plus,
+                                    leadingContent = BezierIcons.Plus,
+                                    trailingContent = BezierIcons.Plus,
                                     enabled = false,
                             )
                         }
@@ -436,8 +436,8 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
                                     size = size,
                                     variant = variant,
                                     semantic = semantic,
-                                    leadingIcon = BezierIcons.Plus,
-                                    trailingIcon = BezierIcons.Plus,
+                                    leadingContent = BezierIcons.Plus,
+                                    trailingContent = BezierIcons.Plus,
                                     isLoading = true,
                             )
                         }


### PR DESCRIPTION
## 배경

Figma(🚧 Mobile Components — Button, `1734:146`)를 SSOT로 v3 Button 스펙을 검증하던 중, typography가 코드와 Figma 간 한 단계 어긋나 있었음. `2. semantic_typography/Mobile.tokens.json`의 label 토큰을 기준으로 정렬함.

## 변경 사항

### 1. BezierTypo label 토큰 값 수정 (`BezierTypography.kt`)
Mobile semantic typography 토큰(label)에 맞게 size/line-height 정정. **전역 공용 토큰이라 Button 외 컴포넌트에도 적용됨.**

| 토큰 | as-is (size/lh) | to-be |
|---|---|---|
| `LabelSmall` | 12 / 16 | **13 / 18** |
| `LabelMedium` | 13 / 18 | **14 / 20** |
| `LabelLarge` | 14 / 18 | **15 / 20** |

(weight 700=`Bold`, letter-spacing 0=`Normal`은 토큰과 이미 일치)

### 2. Button typo 매핑 (`v3/component/Button.kt`)
`Text*` → `Label*` 로 매핑하여 Figma label 토큰 사용.

| size | as-is | to-be |
|---|---|---|
| Xsmall | `TextSmall` | `LabelSmall` |
| Small | `TextMedium` | `LabelMedium` |
| Medium | `TextLarge` | `LabelLarge` |

→ Button xsmall/small/medium typography가 Figma와 완전 일치.

### 3. 콘텐츠 슬롯 네이밍 변경 (`v3/component/Button.kt`)
`leadingIcon`/`trailingIcon` → `leadingContent`/`trailingContent` 로 rename. 향후 아이콘 외 콘텐츠(swap 슬롯) 확장을 대비한 이름 변경이며, **타입(`BezierIcon?`)과 동작은 그대로**.

## 검증
- `./gradlew :bezier:compileDebugKotlin` BUILD SUCCESSFUL

## 남은 이슈 (이번 PR 범위 밖)
- Button `large`/`xlarge`는 `TextXLarge`(16/24, letter-spacing `Tight` -0.1)를 사용 중. Figma는 16/24 / letter-spacing 0 이라 **letter-spacing만 불일치**. label 토큰 범위(최대 size 15)를 벗어나 별도 토큰이 필요하므로 후속 논의 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)