### PR TITLE
v3 Button 네이밍 변경에 맞춰 ButtonPlaygroundScreen 파라미터 정렬

### DIFF
--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ButtonPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ButtonPlaygroundScreen.kt
@@ -81,8 +81,8 @@ fun ButtonPlaygroundScreen(onBack: () -> Unit) {
                         isActive = isActive,
                         isLoading = isLoading,
                         enabled = enabled,
-                        leadingIcon = if (showLeadingIcon) BezierIcons.Plus else null,
-                        trailingIcon = if (showTrailingIcon) BezierIcons.Plus else null,
+                        leadingContent = if (showLeadingIcon) BezierIcons.Plus else null,
+                        trailingContent = if (showTrailingIcon) BezierIcons.Plus else null,
                 )
             }
 


### PR DESCRIPTION
## 배경

PR #150(`v3` → `exp`)의 `check-build` 잡이 `:sample:compileDebugKotlin` 단계에서 실패했습니다.

```
e: ButtonPlaygroundScreen.kt:84:25 No parameter with name 'leadingIcon' found.
e: ButtonPlaygroundScreen.kt:85:25 No parameter with name 'trailingIcon' found.
```

PR #149에서 v3 `Button`의 `leadingIcon`/`trailingIcon` 파라미터가 `leadingContent`/`trailingContent`로 변경되었으나, 샘플 앱 `ButtonPlaygroundScreen`이 구 파라미터 이름을 그대로 참조하고 있었습니다.

## 변경

- `ButtonPlaygroundScreen.kt`의 `Button` 호출 인자 `leadingIcon`/`trailingIcon` → `leadingContent`/`trailingContent`

`BooleanControl`의 표시 라벨 문자열(`"leadingIcon"`, `"trailingIcon"`)과 내부 상태 변수명은 컴파일과 무관하여 변경하지 않았습니다.

## 검증

- 로컬 `./gradlew assembleDebug` → **BUILD SUCCESSFUL** (`:sample:compileDebugKotlin` 정상 컴파일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)