### PR TITLE
v3 Tag, Badge 텍스트에 maxLines=1 및 Ellipsis 적용

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Badge.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Badge.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -78,6 +79,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                 typo = BezierTypo.TextXSmall,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         BadgeSize.Small -> BezierText(
@@ -85,6 +88,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                 typo = BezierTypo.TextMedium,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         BadgeSize.Medium -> Text(
@@ -96,6 +101,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                         fontWeight = FontWeight.Normal,
                         color = color,
                 ),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         BadgeSize.Large -> Text(
@@ -107,6 +114,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                         fontWeight = FontWeight.Normal,
                         color = color,
                 ),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
     }
 }

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -83,6 +84,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 typo = BezierTypo.TextXSmall,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         TagSize.Small -> BezierText(
@@ -90,6 +93,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 typo = BezierTypo.TextMedium,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         TagSize.Medium -> Text(
@@ -99,6 +104,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 lineHeight = 18.sp,
                 letterSpacing = (-0.1).sp,
                 fontWeight = FontWeight.Normal,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         TagSize.Large -> Text(
@@ -108,6 +115,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 lineHeight = 20.sp,
                 letterSpacing = (-0.1).sp,
                 fontWeight = FontWeight.Normal,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
     }
 }


### PR DESCRIPTION
## 변경 사항
v3 `Tag`, `Badge`의 모든 size(Xsmall/Small/Medium/Large) 분기 텍스트에 `maxLines = 1`과 `overflow = TextOverflow.Ellipsis`를 지정했습니다. 텍스트가 한 줄로 표시되고, 넘칠 경우 말줄임(…) 처리됩니다.

- `v3/component/Tag.kt` — `TagLabel`의 4개 size 분기
- `v3/component/Badge.kt` — `BadgeText`의 4개 size 분기

## 배경
v1 `Tag`/`Badge`가 `maxLines = 1` + `overflow = Ellipsis` 조합으로 단일 라인을 보장하는 것과 동일한 동작으로 v3를 정렬했습니다.

## 참고 (이번 PR 변경 없음)
v1 `Tag`(`component/Tag.kt`), v1 `Badge`(`component/Badge.kt`) 모두 `maxLines = 1` + `Ellipsis`만 있고 최소/최대 너비 설정은 없는 것을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * Badge 컴포넌트의 텍스트 길이 제한 처리를 개선했습니다. 모든 크기에서 긴 텍스트가 한 줄을 초과할 때 말줄임표로 일관되게 표시됩니다.
  * Tag 컴포넌트의 텍스트 길이 제한 처리를 개선했습니다. 모든 크기에서 긴 라벨이 한 줄을 초과할 때 말줄임표로 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->