### PR TITLE
Merge exp to main

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Badge.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Badge.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -78,6 +79,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                 typo = BezierTypo.TextXSmall,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         BadgeSize.Small -> BezierText(
@@ -85,6 +88,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                 typo = BezierTypo.TextMedium,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         BadgeSize.Medium -> Text(
@@ -96,6 +101,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                         fontWeight = FontWeight.Normal,
                         color = color,
                 ),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         BadgeSize.Large -> Text(
@@ -107,6 +114,8 @@ private fun BadgeText(text: String, size: BadgeSize, color: Color) {
                         fontWeight = FontWeight.Normal,
                         color = color,
                 ),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
     }
 }

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -83,6 +84,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 typo = BezierTypo.TextXSmall,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         TagSize.Small -> BezierText(
@@ -90,6 +93,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 typo = BezierTypo.TextMedium,
                 weight = BezierWeight.Regular,
                 color = color,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         TagSize.Medium -> Text(
@@ -99,6 +104,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 lineHeight = 18.sp,
                 letterSpacing = (-0.1).sp,
                 fontWeight = FontWeight.Normal,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
 
         TagSize.Large -> Text(
@@ -108,6 +115,8 @@ private fun TagLabel(text: String, size: TagSize, color: Color) {
                 lineHeight = 20.sp,
                 letterSpacing = (-0.1).sp,
                 fontWeight = FontWeight.Normal,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
         )
     }
 }


### PR DESCRIPTION
v3 Tag, Badge 텍스트에 maxLines=1 및 Ellipsis 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Badge와 Tag 컴포넌트에서 텍스트가 길 때 자동으로 말줄임표(...)로 처리되도록 개선했습니다. 이제 모든 크기 옵션에서 텍스트가 한 줄로 제한되어 깔끔한 레이아웃을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->