### PR TITLE
[MOB-5403] v3 Avatar 내부 Status를 독립 public 컴포넌트로 분리

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Avatar.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Avatar.kt
@@ -41,7 +41,7 @@ fun Avatar(
         size: AvatarSize = AvatarSize.Size16,
         enabled: Boolean = true,
         showBorder: Boolean = false,
-        status: AvatarStatusType? = null,
+        status: StatusType? = null,
         contentDescription: String? = null,
 ) {
     val layout = size.layout
@@ -74,7 +74,7 @@ fun Avatar(
         )
 
         if (status != null) {
-            AvatarStatus(
+            Status(
                     type = status,
                     size = layout.statusSize,
                     modifier = Modifier.offset(x = layout.statusOffsetX, y = layout.statusOffsetY),
@@ -116,24 +116,24 @@ enum class AvatarSize {
 
     internal val layout: AvatarLayoutSpec
         get() = when (this) {
-            Size16 -> AvatarLayoutSpec(16.dp, 1.dp, AvatarStatusSize.Small, 12.dp, 12.dp)
-            Size20 -> AvatarLayoutSpec(20.dp, 1.dp, AvatarStatusSize.Small, 14.dp, 14.dp)
-            Size24 -> AvatarLayoutSpec(24.dp, 1.5.dp, AvatarStatusSize.Small, 18.dp, 18.dp)
-            Size30 -> AvatarLayoutSpec(30.dp, 1.5.dp, AvatarStatusSize.Medium, 21.dp, 20.dp)
-            Size36 -> AvatarLayoutSpec(36.dp, 1.5.dp, AvatarStatusSize.Medium, 26.dp, 26.dp)
-            Size42 -> AvatarLayoutSpec(42.dp, 2.dp, AvatarStatusSize.Medium, 32.dp, 32.dp)
-            Size48 -> AvatarLayoutSpec(48.dp, 2.dp, AvatarStatusSize.Medium, 36.dp, 37.dp)
-            Size72 -> AvatarLayoutSpec(72.dp, 2.5.dp, AvatarStatusSize.Large, 55.dp, 54.dp)
-            Size90 -> AvatarLayoutSpec(90.dp, 3.dp, AvatarStatusSize.XLarge, 68.dp, 68.dp)
-            Size120 -> AvatarLayoutSpec(120.dp, 3.5.dp, AvatarStatusSize.XLarge, 96.dp, 94.dp)
-            Size160 -> AvatarLayoutSpec(160.dp, 4.dp, AvatarStatusSize.XLarge, 132.dp, 129.dp)
+            Size16 -> AvatarLayoutSpec(16.dp, 1.dp, StatusSize.Small, 12.dp, 12.dp)
+            Size20 -> AvatarLayoutSpec(20.dp, 1.dp, StatusSize.Small, 14.dp, 14.dp)
+            Size24 -> AvatarLayoutSpec(24.dp, 1.5.dp, StatusSize.Small, 18.dp, 18.dp)
+            Size30 -> AvatarLayoutSpec(30.dp, 1.5.dp, StatusSize.Medium, 21.dp, 20.dp)
+            Size36 -> AvatarLayoutSpec(36.dp, 1.5.dp, StatusSize.Medium, 26.dp, 26.dp)
+            Size42 -> AvatarLayoutSpec(42.dp, 2.dp, StatusSize.Medium, 32.dp, 32.dp)
+            Size48 -> AvatarLayoutSpec(48.dp, 2.dp, StatusSize.Medium, 36.dp, 37.dp)
+            Size72 -> AvatarLayoutSpec(72.dp, 2.5.dp, StatusSize.Large, 55.dp, 54.dp)
+            Size90 -> AvatarLayoutSpec(90.dp, 3.dp, StatusSize.XLarge, 68.dp, 68.dp)
+            Size120 -> AvatarLayoutSpec(120.dp, 3.5.dp, StatusSize.XLarge, 96.dp, 94.dp)
+            Size160 -> AvatarLayoutSpec(160.dp, 4.dp, StatusSize.XLarge, 132.dp, 129.dp)
         }
 }
 
 internal data class AvatarLayoutSpec(
         val length: Dp,
         val borderWidth: Dp,
-        val statusSize: AvatarStatusSize,
+        val statusSize: StatusSize,
         val statusOffsetX: Dp,
         val statusOffsetY: Dp,
 )
@@ -142,7 +142,7 @@ internal data class AvatarLayoutSpec(
 private fun AvatarMatrix(
         enabled: Boolean,
         showBorder: Boolean,
-        status: AvatarStatusType?,
+        status: StatusType?,
 ) {
     val previewImage = ColorPainter(Color(0xFFB6CED6))
 
@@ -189,8 +189,8 @@ private fun AvatarMatrixDisabledPreview() = AvatarMatrix(enabled = false, showBo
 
 @Preview(showBackground = true, widthDp = 320, heightDp = 1200)
 @Composable
-private fun AvatarMatrixBorderStatusPreview() = AvatarMatrix(enabled = true, showBorder = true, status = AvatarStatusType.Online)
+private fun AvatarMatrixBorderStatusPreview() = AvatarMatrix(enabled = true, showBorder = true, status = StatusType.Online)
 
 @Preview(showBackground = true, widthDp = 320, heightDp = 1200, uiMode = UI_MODE_NIGHT_YES)
 @Composable
-private fun AvatarMatrixDarkPreview() = AvatarMatrix(enabled = true, showBorder = true, status = AvatarStatusType.OnlineDnd)
+private fun AvatarMatrixDarkPreview() = AvatarMatrix(enabled = true, showBorder = true, status = StatusType.OnlineDnd)

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Status.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Status.kt
@@ -21,10 +21,10 @@ import io.channel.bezier.icon.Lock
 import io.channel.bezier.icon.MoonFilled
 
 @Composable
-internal fun AvatarStatus(
-        type: AvatarStatusType,
-        size: AvatarStatusSize,
+fun Status(
+        type: StatusType,
         modifier: Modifier = Modifier,
+        size: StatusSize = StatusSize.Small,
 ) {
     val colors = BezierTheme.colorsV3
     val layout = size.layout
@@ -39,22 +39,22 @@ internal fun AvatarStatus(
             contentAlignment = Alignment.Center,
     ) {
         when (type) {
-            AvatarStatusType.Online,
-            AvatarStatusType.Offline -> Box(
+            StatusType.Online,
+            StatusType.Offline -> Box(
                     modifier = Modifier
                             .size(layout.inner)
                             .clip(CircleShape)
                             .background(innerColor),
             )
 
-            AvatarStatusType.Lock -> Icon(
+            StatusType.Lock -> Icon(
                     modifier = Modifier.size(layout.inner),
                     imageVector = BezierIcons.Lock.imageVector,
                     tint = innerColor,
                     contentDescription = null,
             )
 
-            AvatarStatusType.OnlineDnd, AvatarStatusType.OfflineDnd -> Icon(
+            StatusType.OnlineDnd, StatusType.OfflineDnd -> Icon(
                     modifier = Modifier.size(layout.inner),
                     imageVector = BezierIcons.MoonFilled.imageVector,
                     tint = innerColor,
@@ -64,7 +64,7 @@ internal fun AvatarStatus(
     }
 }
 
-enum class AvatarStatusType {
+enum class StatusType {
     Online,
     Offline,
     Lock,
@@ -81,36 +81,36 @@ enum class AvatarStatusType {
     }
 }
 
-internal enum class AvatarStatusSize {
+enum class StatusSize {
     Small,
     Medium,
     Large,
     XLarge;
 
-    internal val layout: AvatarStatusLayoutSpec
+    internal val layout: StatusLayoutSpec
         get() = when (this) {
-            Small -> AvatarStatusLayoutSpec(
+            Small -> StatusLayoutSpec(
                     container = 8.dp,
                     padding = 2.dp,
                     inner = 6.dp,
                     cornerRadius = 4.dp,
             )
 
-            Medium -> AvatarStatusLayoutSpec(
+            Medium -> StatusLayoutSpec(
                     container = 12.dp,
                     padding = 2.dp,
                     inner = 8.dp,
                     cornerRadius = 6.dp,
             )
 
-            Large -> AvatarStatusLayoutSpec(
+            Large -> StatusLayoutSpec(
                     container = 16.dp,
                     padding = 3.dp,
                     inner = 12.dp,
                     cornerRadius = 8.dp,
             )
 
-            XLarge -> AvatarStatusLayoutSpec(
+            XLarge -> StatusLayoutSpec(
                     container = 24.dp,
                     padding = 2.dp,
                     inner = 18.dp,
@@ -119,7 +119,7 @@ internal enum class AvatarStatusSize {
         }
 }
 
-internal data class AvatarStatusLayoutSpec(
+internal data class StatusLayoutSpec(
         val container: Dp,
         val padding: Dp,
         val inner: Dp,

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -29,6 +29,8 @@ import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.StatusPlaygroundKey
+import io.channel.bezier.compose.sample.playground.StatusPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.TagPlaygroundKey
 import io.channel.bezier.compose.sample.playground.TagPlaygroundScreen
 
@@ -65,6 +67,7 @@ private fun PlaygroundApp() {
                                     onSelectAvatar = { backStack.add(AvatarPlaygroundKey) },
                                     onSelectAvatarGroup = { backStack.add(AvatarGroupPlaygroundKey) },
                                     onSelectSpinner = { backStack.add(SpinnerPlaygroundKey) },
+                                    onSelectStatus = { backStack.add(StatusPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -87,6 +90,9 @@ private fun PlaygroundApp() {
                         }
                         entry<SpinnerPlaygroundKey> {
                             SpinnerPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<StatusPlaygroundKey> {
+                            StatusPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -24,6 +24,7 @@ fun ComponentListScreen(
         onSelectAvatar: () -> Unit,
         onSelectAvatarGroup: () -> Unit,
         onSelectSpinner: () -> Unit,
+        onSelectStatus: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -51,6 +52,8 @@ fun ComponentListScreen(
             ComponentRow("AvatarGroup", onClick = onSelectAvatarGroup)
             Divider()
             ComponentRow("Spinner", onClick = onSelectSpinner)
+            Divider()
+            ComponentRow("Status", onClick = onSelectStatus)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -8,3 +8,4 @@ data object TagPlaygroundKey
 data object AvatarPlaygroundKey
 data object AvatarGroupPlaygroundKey
 data object SpinnerPlaygroundKey
+data object StatusPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/StatusPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/StatusPlaygroundScreen.kt
@@ -19,33 +19,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.icon.ArrowLeft
-import io.channel.bezier.v3.component.Avatar
-import io.channel.bezier.v3.component.AvatarSize
 import io.channel.bezier.v3.component.IconButton
 import io.channel.bezier.v3.component.IconButtonSize
 import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.Status
+import io.channel.bezier.v3.component.StatusSize
 import io.channel.bezier.v3.component.StatusType
 
 @Composable
-fun AvatarPlaygroundScreen(onBack: () -> Unit) {
-    var size by remember { mutableStateOf(AvatarSize.Size48) }
-    var enabled by remember { mutableStateOf(true) }
-    var showBorder by remember { mutableStateOf(false) }
-    var showStatus by remember { mutableStateOf(false) }
-    var statusType by remember { mutableStateOf(StatusType.Online) }
-
-    val previewPainter = remember { ColorPainter(Color(0xFFB6CED6)) }
+fun StatusPlaygroundScreen(onBack: () -> Unit) {
+    var type by remember { mutableStateOf(StatusType.Online) }
+    var size by remember { mutableStateOf(StatusSize.XLarge) }
 
     Scaffold(
             topBar = {
                 TopAppBar(
-                        title = { Text("Avatar") },
+                        title = { Text("Status") },
                         navigationIcon = {
                             IconButton(
                                     icon = BezierIcons.ArrowLeft,
@@ -71,23 +64,13 @@ fun AvatarPlaygroundScreen(onBack: () -> Unit) {
                             .padding(32.dp),
                     contentAlignment = Alignment.Center,
             ) {
-                Avatar(
-                        image = previewPainter,
-                        size = size,
-                        enabled = enabled,
-                        showBorder = showBorder,
-                        status = if (showStatus) statusType else null,
-                        contentDescription = "preview",
-                )
+                Status(type = type, size = size)
             }
 
             Divider()
 
-            EnumControl("Size", AvatarSize.values(), size) { size = it }
-            BooleanControl("enabled", enabled) { enabled = it }
-            BooleanControl("showBorder", showBorder) { showBorder = it }
-            BooleanControl("showStatus", showStatus) { showStatus = it }
-            EnumControl("statusType", StatusType.values(), statusType) { statusType = it }
+            EnumControl("type", StatusType.values(), type) { type = it }
+            EnumControl("Size", StatusSize.values(), size) { size = it }
         }
     }
 }


### PR DESCRIPTION
## 배경
V3 `AvatarStatus`는 `internal`이라 라이브러리 외부에서 사용할 수 없고, 실질적으로 `Avatar` 내부 부속으로만 렌더됐습니다. Status를 독립적으로도 쓸 수 있도록 public 컴포넌트로 분리합니다.

## 변경
- `v3/component/AvatarStatus.kt` → `v3/component/Status.kt` 로 분리
  - `internal fun AvatarStatus` → `fun Status(type, modifier, size = StatusSize.Small)` **(public)**
  - `AvatarStatusType` → `StatusType` **(public)**
  - `AvatarStatusSize`(internal) → `StatusSize` **(public 승격)**
  - `AvatarStatusLayoutSpec` → `StatusLayoutSpec` (internal 유지)
- `Avatar`는 내부에서 public `Status`를 호출하도록 재배선 (동작/렌더 결과 동일)
- sample: `StatusPlaygroundScreen` 추가 + `ComponentListScreen`/`NavKeys`/`MainActivity` 배선

## 네이밍 근거
V2/V3가 `Avatar/Badge/Tag`를 각 패키지에서 병렬로 두는 관례 + V2에 이미 public `Status/StatusType/StatusSize`가 존재 → V3 패키지의 `Status`가 정확한 대응.

## 검증
- `:sample:compileDebugKotlin` 통과
- 실기기(SM-S918N) 설치 후 `v3 Components → Status` 플레이그라운드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 아바타 상태 표시가 더 범용적인 상태 컴포넌트로 개편되었습니다.
  * 상태 표시를 직접 조정해볼 수 있는 새 Playground 화면이 추가되었습니다.
  * 컴포넌트 목록에서 상태 항목을 선택해 해당 화면으로 이동할 수 있습니다.

* **Bug Fixes**
  * 아바타와 상태 표시의 타입 및 크기 매핑이 최신 규격에 맞게 정리되었습니다.
  * 상태 표시 프리뷰가 확장되어 다양한 상태를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->