### PR TITLE
[MOB-6299] Divider 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Divider.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Divider.kt
@@ -1,0 +1,64 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+
+@Composable
+fun Divider(
+        modifier: Modifier = Modifier,
+        sideIndent: Boolean = true,
+        parallelIndent: Boolean = true,
+) {
+    Box(
+            modifier = modifier
+                    .fillMaxWidth()
+                    .padding(
+                            horizontal = if (sideIndent) DividerIndent else 0.dp,
+                            vertical = if (parallelIndent) DividerIndent else 0.dp,
+                    ),
+    ) {
+        Box(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .height(DividerThickness)
+                        .background(BezierTheme.colorsV3.borderNeutral),
+        )
+    }
+}
+
+private val DividerIndent: Dp = 6.dp
+private val DividerThickness: Dp = 1.dp
+
+@Composable
+private fun DividerMatrix() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            Divider()
+            Divider(sideIndent = false)
+            Divider(parallelIndent = false)
+            Divider(sideIndent = false, parallelIndent = false)
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Preview(showBackground = true, widthDp = 360, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun DividerMatrixPreview() = DividerMatrix()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -25,6 +25,8 @@ import io.channel.bezier.compose.sample.playground.ButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ComponentListKey
 import io.channel.bezier.compose.sample.playground.ComponentListScreen
+import io.channel.bezier.compose.sample.playground.DividerPlaygroundKey
+import io.channel.bezier.compose.sample.playground.DividerPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundKey
@@ -68,6 +70,7 @@ private fun PlaygroundApp() {
                                     onSelectAvatarGroup = { backStack.add(AvatarGroupPlaygroundKey) },
                                     onSelectSpinner = { backStack.add(SpinnerPlaygroundKey) },
                                     onSelectStatus = { backStack.add(StatusPlaygroundKey) },
+                                    onSelectDivider = { backStack.add(DividerPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -93,6 +96,9 @@ private fun PlaygroundApp() {
                         }
                         entry<StatusPlaygroundKey> {
                             StatusPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<DividerPlaygroundKey> {
+                            DividerPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -25,6 +25,7 @@ fun ComponentListScreen(
         onSelectAvatarGroup: () -> Unit,
         onSelectSpinner: () -> Unit,
         onSelectStatus: () -> Unit,
+        onSelectDivider: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -54,6 +55,8 @@ fun ComponentListScreen(
             ComponentRow("Spinner", onClick = onSelectSpinner)
             Divider()
             ComponentRow("Status", onClick = onSelectStatus)
+            Divider()
+            ComponentRow("Divider", onClick = onSelectDivider)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/DividerPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/DividerPlaygroundScreen.kt
@@ -1,0 +1,74 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider as MaterialDivider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.Divider
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun DividerPlaygroundScreen(onBack: () -> Unit) {
+    var sideIndent by remember { mutableStateOf(true) }
+    var parallelIndent by remember { mutableStateOf(true) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Divider") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Column(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(vertical = 32.dp),
+            ) {
+                Divider(
+                        sideIndent = sideIndent,
+                        parallelIndent = parallelIndent,
+                )
+            }
+
+            MaterialDivider()
+
+            BooleanControl("sideIndent", sideIndent) { sideIndent = it }
+            BooleanControl("parallelIndent", parallelIndent) { parallelIndent = it }
+        }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -9,3 +9,4 @@ data object AvatarPlaygroundKey
 data object AvatarGroupPlaygroundKey
 data object SpinnerPlaygroundKey
 data object StatusPlaygroundKey
+data object DividerPlaygroundKey


### PR DESCRIPTION
## 개요
v3 `Divider` 컴포넌트를 구현하고 샘플 플레이그라운드에 등록합니다.

Figma: [🚧 Mobile-Components (node 3353:9)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=3353-9)

## 변경 사항
**신규**
- `bezier/.../v3/component/Divider.kt` — 1dp 수평 구분선
  - `sideIndent: Boolean = true` (좌우 6dp), `parallelIndent: Boolean = true` (상하 6dp)
  - color: `BezierTheme.colorsV3.borderNeutral` (`color/border/neutral`, #00000014)
  - width fill, dark/light Preview 포함
- `sample/.../playground/DividerPlaygroundScreen.kt` — indent 토글 2개

**수정**
- `NavKeys.kt` / `ComponentListScreen.kt` / `MainActivity.kt` — 플레이그라운드 등록·네비게이션 배선

## 설계 결정
- Figma property 축의 `orientation` 값 중 `(임시) 0.5`는 **제외**했습니다. 컴포넌트 description이 *"orientation: horizontal만 지원 (vertical은 web 전용, Mobile 미지원)"*, *"1px 구분선"*으로 명시하고 `(임시)`는 임시(WIP) 값이기 때문입니다. 지원값이 `horizontal` 단일이라 `orientation` property 자체를 노출하지 않았습니다.

## 검증
- `:bezier:compileDebugKotlin` BUILD SUCCESSFUL
- `:sample:compileDebugKotlin` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)