### PR TITLE
[MOB-6298] v3 Toast 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Toast.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Toast.kt
@@ -1,0 +1,122 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.CheckCircleFilled
+import io.channel.bezier.icon.ErrorDiamondFilled
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+@Composable
+fun Toast(
+        text: String,
+        modifier: Modifier = Modifier,
+        preset: ToastPreset = ToastPreset.Info,
+) {
+    val colors = BezierTheme.colorsV3
+    val iconSource = preset.iconSource
+
+    Row(
+            modifier = modifier
+                    .widthIn(max = ToastMaxWidth)
+                    .heightIn(min = ToastMinHeight)
+                    .clip(CircleShape)
+                    .background(colors.fillGreyHeavier)
+                    .padding(horizontal = preset.horizontalPadding, vertical = ToastVerticalPadding),
+            horizontalArrangement = Arrangement.spacedBy(ToastIconTextGap),
+            verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (iconSource != null) {
+            Icon(
+                    modifier = Modifier.size(ToastIconLength),
+                    imageVector = iconSource.imageVector,
+                    tint = colors.iconNeutralHeavy,
+                    contentDescription = null,
+            )
+        }
+        BezierText(
+                modifier = Modifier.weight(1f, fill = false),
+                text = text,
+                typo = BezierTypo.TextMedium,
+                weight = BezierWeight.Bold,
+                color = colors.textNeutral,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = ToastMaxLines,
+        )
+    }
+}
+
+private val ToastMaxWidth: Dp = 460.dp
+private val ToastMinHeight: Dp = 40.dp
+private val ToastVerticalPadding: Dp = 10.dp
+private val ToastIconTextGap: Dp = 6.dp
+private val ToastIconLength: Dp = 20.dp
+private const val ToastMaxLines: Int = 2
+
+enum class ToastPreset {
+    Info,
+    Success,
+    Error;
+
+    internal val iconSource: BezierIcon?
+        get() = when (this) {
+            Info -> null
+            Success -> BezierIcons.CheckCircleFilled
+            Error -> BezierIcons.ErrorDiamondFilled
+        }
+
+    internal val horizontalPadding: Dp
+        get() = when (this) {
+            Info -> 14.dp
+            Success, Error -> 12.dp
+        }
+}
+
+@Composable
+private fun ToastMatrix() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Toast(text = "Message", preset = ToastPreset.Info)
+            Toast(text = "Message", preset = ToastPreset.Success)
+            Toast(text = "Message", preset = ToastPreset.Error)
+            Toast(
+                    text = "This is a very long toast message that should wrap into at most two lines and then be truncated with an ellipsis once it overflows the available width",
+                    preset = ToastPreset.Error,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 520)
+@Composable
+private fun ToastMatrixLightPreview() = ToastMatrix()
+
+@Preview(showBackground = true, widthDp = 520, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun ToastMatrixDarkPreview() = ToastMatrix()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -35,6 +35,8 @@ import io.channel.bezier.compose.sample.playground.StatusPlaygroundKey
 import io.channel.bezier.compose.sample.playground.StatusPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.TagPlaygroundKey
 import io.channel.bezier.compose.sample.playground.TagPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.ToastPlaygroundKey
+import io.channel.bezier.compose.sample.playground.ToastPlaygroundScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,6 +73,7 @@ private fun PlaygroundApp() {
                                     onSelectSpinner = { backStack.add(SpinnerPlaygroundKey) },
                                     onSelectStatus = { backStack.add(StatusPlaygroundKey) },
                                     onSelectDivider = { backStack.add(DividerPlaygroundKey) },
+                                    onSelectToast = { backStack.add(ToastPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -99,6 +102,9 @@ private fun PlaygroundApp() {
                         }
                         entry<DividerPlaygroundKey> {
                             DividerPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<ToastPlaygroundKey> {
+                            ToastPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -26,6 +26,7 @@ fun ComponentListScreen(
         onSelectSpinner: () -> Unit,
         onSelectStatus: () -> Unit,
         onSelectDivider: () -> Unit,
+        onSelectToast: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -57,6 +58,8 @@ fun ComponentListScreen(
             ComponentRow("Status", onClick = onSelectStatus)
             Divider()
             ComponentRow("Divider", onClick = onSelectDivider)
+            Divider()
+            ComponentRow("Toast", onClick = onSelectToast)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -10,3 +10,4 @@ data object AvatarGroupPlaygroundKey
 data object SpinnerPlaygroundKey
 data object StatusPlaygroundKey
 data object DividerPlaygroundKey
+data object ToastPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ToastPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ToastPlaygroundScreen.kt
@@ -1,0 +1,81 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.Toast
+import io.channel.bezier.v3.component.ToastPreset
+
+private const val LongToastText =
+        "This is a very long toast message that should wrap into at most two lines and then be truncated with an ellipsis once it overflows the available width"
+
+@Composable
+fun ToastPlaygroundScreen(onBack: () -> Unit) {
+    var preset by remember { mutableStateOf(ToastPreset.Info) }
+    var longText by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Toast") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Toast(
+                        text = if (longText) LongToastText else "Message",
+                        preset = preset,
+                )
+            }
+
+            Divider()
+
+            EnumControl("Preset", ToastPreset.values(), preset) { preset = it }
+            BooleanControl("Long text", longText) { longText = it }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
Figma Mobile Components의 Toast(node 2090:17)를 v3 패키지에 구현합니다. Figma를 SSOT로 삼아 spec 검증(7종) → 구현 → 구현 검증 파이프라인을 통과했습니다.

## 변경
- `bezier/.../v3/component/Toast.kt` (신규)
  - `Toast(text: String, modifier, preset: ToastPreset = Info)`
  - `preset`: `Info`(아이콘 없음) / `Success`(CheckCircleFilled) / `Error`(ErrorDiamondFilled)
  - pill(CircleShape) 배경 `fillGreyHeavier`, 텍스트 `BezierTypo.TextMedium` + `Bold` + `textNeutral`, **최대 2줄** ellipsis
  - 아이콘 20dp, `iconNeutralHeavy`
  - 레이아웃: min-h 40 / max-w 460 / py 10 / px 14(info)·12(icon) / gap 6
- 플레이그라운드: `ToastPlaygroundScreen.kt` 신규 + `NavKeys`/`ComponentListScreen`/`MainActivity` 배선

## SSOT 검증
- Spec 검증 7/7 ✅ (Properties·Layout·Color·Typography·Asset·Noise·ImplRef)
- 구현 검증 ✅ (불일치 0건), `:bezier`·`:sample` 컴파일 통과

## 알려진 결정 사항
- **backdrop blur 미구현**: Figma `Backdrop/small`(BACKGROUND_BLUR)은 fill이 불투명 `#313135`라 시각적으로 무의미하고 저장소 blur 인프라 선례가 없어 제외. glass(반투명) 의도라면 별도 인프라 필요.
- **배경 fill은 테마 추종 토큰**(`fillGreyHeavier`): Figma 변수 바인딩에 1:1 충실. '항상 다크' 의도라면 고정 토큰 필요 — 디자이너 확인 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)