### PR TITLE
[MOB-6296] Add v3 Switch component

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
@@ -1,0 +1,220 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.typography.BezierTypo
+
+private val TrackWidth = 50.dp
+private val TrackHeight = 28.dp
+private val ThumbSize = 24.dp
+private val ThumbPadding = 2.dp
+private val ThumbTravel = TrackWidth - ThumbSize - ThumbPadding * 2
+private val ThumbElevation = 6.dp
+private val ErrorRingGap = 3.dp
+private val ErrorRingBorder = 1.5.dp
+private const val DisabledAlpha = 0.4f
+private val ThumbAnimationSpec = tween<Float>(durationMillis = 200, easing = EaseInOut)
+
+@Composable
+fun Switch(
+        checked: Boolean,
+        onCheckedChange: ((Boolean) -> Unit)?,
+        modifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        hasError: Boolean = false,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = BezierTheme.colorsV3
+
+    val progress = animateFloatAsState(
+            targetValue = if (checked) 1f else 0f,
+            animationSpec = ThumbAnimationSpec,
+            label = "SwitchThumbProgress",
+    )
+
+    val uncheckedTrackColor = colors.fillNeutralHeavy
+    val checkedTrackColor = colors.fillNeutralHeaviest
+    val thumbColor = colors.iconInverseHeavier
+    val ringColor = colors.stateWarning
+
+    val trackShape = RoundedCornerShape(percent = 50)
+
+    val errorBorderModifier = if (hasError) {
+        Modifier.outsideBorder(
+                color = ringColor,
+                shape = trackShape,
+                gap = ErrorRingGap,
+                borderWidth = ErrorRingBorder,
+        )
+    } else {
+        Modifier
+    }
+
+    Box(
+            modifier = modifier
+                    .size(width = TrackWidth, height = TrackHeight)
+                    .then(errorBorderModifier)
+                    .graphicsLayer { alpha = if (enabled) 1f else DisabledAlpha }
+                    .drawBehind {
+                        drawOutline(
+                                outline = trackShape.createOutline(size, layoutDirection, this),
+                                color = lerp(uncheckedTrackColor, checkedTrackColor, progress.value),
+                        )
+                    }
+                    .then(
+                            if (onCheckedChange != null) {
+                                Modifier.clickable(
+                                        interactionSource = interactionSource,
+                                        indication = null,
+                                        enabled = enabled,
+                                        onClick = { onCheckedChange(!checked) },
+                                )
+                            } else {
+                                Modifier
+                            },
+                    ),
+            contentAlignment = Alignment.TopStart,
+    ) {
+        Box(
+                modifier = Modifier
+                        .graphicsLayer {
+                            translationX = ThumbPadding.toPx() + ThumbTravel.toPx() * progress.value
+                            translationY = ThumbPadding.toPx()
+                        }
+                        .size(ThumbSize)
+                        .shadow(
+                                elevation = ThumbElevation,
+                                shape = CircleShape,
+                        )
+                        .background(
+                                color = thumbColor,
+                                shape = CircleShape,
+                        ),
+        )
+    }
+}
+
+private fun Modifier.outsideBorder(
+        color: Color,
+        shape: Shape,
+        gap: Dp,
+        borderWidth: Dp,
+) = drawBehind {
+    val borderWidthPx = borderWidth.toPx()
+    val grow = gap.toPx() - borderWidthPx / 2f
+    val grownSize = Size(
+            width = size.width + grow * 2f,
+            height = size.height + grow * 2f,
+    )
+    val outline = shape.createOutline(grownSize, layoutDirection, this)
+    translate(left = -grow, top = -grow) {
+        drawOutline(
+                outline = outline,
+                color = color,
+                style = Stroke(width = borderWidthPx),
+        )
+    }
+}
+
+@Composable
+private fun SwitchMatrix() {
+    val labelColWidth = 88.dp
+    val cellWidth = 96.dp
+
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(modifier = Modifier.width(labelColWidth))
+                listOf("default", "disabled", "error").forEach { stateLabel ->
+                    Box(
+                            modifier = Modifier.width(cellWidth),
+                            contentAlignment = Alignment.Center,
+                    ) {
+                        BezierText(
+                                text = stateLabel,
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                }
+            }
+
+            listOf(false, true).forEach { checked ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                            modifier = Modifier.width(labelColWidth),
+                            contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BezierText(
+                                text = if (checked) "on" else "off",
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                    SwitchCell(cellWidth) {
+                        Switch(checked = checked, onCheckedChange = {})
+                    }
+                    SwitchCell(cellWidth) {
+                        Switch(checked = checked, onCheckedChange = {}, enabled = false)
+                    }
+                    SwitchCell(cellWidth) {
+                        Switch(checked = checked, onCheckedChange = {}, hasError = true)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SwitchCell(width: Dp, content: @Composable () -> Unit) {
+    Box(
+            modifier = Modifier.width(width),
+            contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+@Preview(showBackground = true, widthDp = 400)
+@Preview(showBackground = true, widthDp = 400, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun SwitchMatrixPreview() = SwitchMatrix()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -31,6 +31,8 @@ import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.StatusPlaygroundKey
 import io.channel.bezier.compose.sample.playground.StatusPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.SwitchPlaygroundKey
+import io.channel.bezier.compose.sample.playground.SwitchPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.TagPlaygroundKey
 import io.channel.bezier.compose.sample.playground.TagPlaygroundScreen
 
@@ -68,6 +70,7 @@ private fun PlaygroundApp() {
                                     onSelectAvatarGroup = { backStack.add(AvatarGroupPlaygroundKey) },
                                     onSelectSpinner = { backStack.add(SpinnerPlaygroundKey) },
                                     onSelectStatus = { backStack.add(StatusPlaygroundKey) },
+                                    onSelectSwitch = { backStack.add(SwitchPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -93,6 +96,9 @@ private fun PlaygroundApp() {
                         }
                         entry<StatusPlaygroundKey> {
                             StatusPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<SwitchPlaygroundKey> {
+                            SwitchPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -25,6 +25,7 @@ fun ComponentListScreen(
         onSelectAvatarGroup: () -> Unit,
         onSelectSpinner: () -> Unit,
         onSelectStatus: () -> Unit,
+        onSelectSwitch: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -54,6 +55,8 @@ fun ComponentListScreen(
             ComponentRow("Spinner", onClick = onSelectSpinner)
             Divider()
             ComponentRow("Status", onClick = onSelectStatus)
+            Divider()
+            ComponentRow("Switch", onClick = onSelectSwitch)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -9,3 +9,4 @@ data object AvatarPlaygroundKey
 data object AvatarGroupPlaygroundKey
 data object SpinnerPlaygroundKey
 data object StatusPlaygroundKey
+data object SwitchPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/SwitchPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/SwitchPlaygroundScreen.kt
@@ -1,0 +1,81 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.Switch
+
+@Composable
+fun SwitchPlaygroundScreen(onBack: () -> Unit) {
+    var checked by remember { mutableStateOf(false) }
+    var enabled by remember { mutableStateOf(true) }
+    var hasError by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Switch") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Switch(
+                        checked = checked,
+                        onCheckedChange = { checked = it },
+                        enabled = enabled,
+                        hasError = hasError,
+                )
+            }
+
+            Divider()
+
+            BooleanControl("checked", checked) { checked = it }
+            BooleanControl("enabled", enabled) { enabled = it }
+            BooleanControl("hasError", hasError) { hasError = it }
+        }
+    }
+}


### PR DESCRIPTION
## 요약
v3 패키지에 Switch 컴포넌트 신규 구현 (Figma node `1095:19`).

## 구현
- Property: `checked` / `enabled` / `hasError` (Figma 6 variant)
- 클릭 전용 토글(드래그/스와이프 없음), 노브 슬라이드 애니메이션은 기존 Switch(`component/Switch.kt`)의 `tween(200, EaseInOut)` 참고
- 색상(Figma SSOT): ON `fillNeutralHeaviest`, OFF `fillNeutralHeavy`, 노브 `iconInverseHeavier`, error 링 `stateWarning`
- error 링은 Avatar의 `outsideBorder` 방식(`createOutline` + `translate` + `drawOutline`)과 동일
- 애니메이션 최적화: 트랙 색 `drawBehind`, 노브 위치 `graphicsLayer { translationX }` → 프레임당 recomposition 제거
- stateless(controlled) — v3 Button·IconButton·Tag와 동일 패턴
- sample 플레이그라운드 배선 (`SwitchPlaygroundScreen` + 목록/네비)

## 검증
- Figma SSOT ↔ SPEC ↔ 구현 대조 통과
- 실기기 렌더 확인 (OFF / ON / error), 라이트·다크 Matrix 프리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)