### PR TITLE
[MOB-6297] v3 ProgressBar 컴포넌트 추가

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/ProgressBar.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/ProgressBar.kt
@@ -1,0 +1,129 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.annotation.IntRange
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.typography.BezierTypo
+
+@Composable
+fun ProgressBar(
+        @IntRange(from = 0, to = 100) progress: Int,
+        modifier: Modifier = Modifier,
+        size: ProgressBarSize = ProgressBarSize.Medium,
+        variant: ProgressBarVariant = ProgressBarVariant.Default,
+) {
+    val fraction = animateFloatAsState(
+            targetValue = progress.coerceIn(0, 100) / 100f,
+            animationSpec = tween(
+                    durationMillis = 1000,
+                    easing = CubicBezierEasing(0.24f, 1f, 0.24f, 1f),
+            ),
+            label = "ProgressBarAnimation",
+    )
+
+    val trackColor = when (variant) {
+        ProgressBarVariant.Default -> BezierTheme.colorsV3.fillNeutralHeavy
+        ProgressBarVariant.Overlaid -> BezierTheme.colorsV3.fillGreyHeavier
+    }
+    val fillColor = BezierTheme.colorsV3.fillNeutralHeaviest
+    val barRadius = size.radius
+
+    Spacer(
+            modifier = modifier
+                    .height(size.height)
+                    .drawBehind {
+                        val radiusPx = barRadius.toPx()
+                        drawRoundRect(
+                                color = trackColor,
+                                cornerRadius = CornerRadius(radiusPx),
+                        )
+
+                        val fillWidth = this.size.width * fraction.value
+                        if (fillWidth > 0f) {
+                            drawRoundRect(
+                                    color = fillColor,
+                                    size = Size(fillWidth, this.size.height),
+                                    cornerRadius = CornerRadius(minOf(radiusPx, fillWidth / 2f)),
+                            )
+                        }
+                    },
+    )
+}
+
+enum class ProgressBarSize {
+    Medium,
+    Small;
+
+    internal val height: Dp
+        get() = when (this) {
+            Medium -> 6.dp
+            Small -> 4.dp
+        }
+
+    internal val radius: Dp
+        get() = when (this) {
+            Medium -> 3.dp
+            Small -> 2.dp
+        }
+}
+
+enum class ProgressBarVariant {
+    Default,
+    Overlaid,
+}
+
+@Composable
+private fun ProgressBarMatrix() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            listOf(0, 30, 60, 100).forEach { progress ->
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    BezierText(
+                            text = "progress = $progress",
+                            typo = BezierTypo.TextMedium,
+                            color = BezierTheme.colorsV3.textNeutral,
+                    )
+                    ProgressBarVariant.values().forEach { variant ->
+                        ProgressBarSize.values().forEach { size ->
+                            ProgressBar(
+                                    modifier = Modifier.width(240.dp),
+                                    progress = progress,
+                                    size = size,
+                                    variant = variant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 320)
+@Preview(showBackground = true, widthDp = 320, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun ProgressBarMatrixPreview() = ProgressBarMatrix()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -29,6 +29,8 @@ import io.channel.bezier.compose.sample.playground.DividerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.DividerPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundKey
+import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.StatusPlaygroundKey
@@ -73,6 +75,7 @@ private fun PlaygroundApp() {
                                     onSelectAvatar = { backStack.add(AvatarPlaygroundKey) },
                                     onSelectAvatarGroup = { backStack.add(AvatarGroupPlaygroundKey) },
                                     onSelectSpinner = { backStack.add(SpinnerPlaygroundKey) },
+                                    onSelectProgressBar = { backStack.add(ProgressBarPlaygroundKey) },
                                     onSelectStatus = { backStack.add(StatusPlaygroundKey) },
                                     onSelectSwitch = { backStack.add(SwitchPlaygroundKey) },
                                     onSelectDivider = { backStack.add(DividerPlaygroundKey) },
@@ -99,6 +102,9 @@ private fun PlaygroundApp() {
                         }
                         entry<SpinnerPlaygroundKey> {
                             SpinnerPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<ProgressBarPlaygroundKey> {
+                            ProgressBarPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                         entry<StatusPlaygroundKey> {
                             StatusPlaygroundScreen(onBack = { backStack.removeLastOrNull() })

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -24,6 +24,7 @@ fun ComponentListScreen(
         onSelectAvatar: () -> Unit,
         onSelectAvatarGroup: () -> Unit,
         onSelectSpinner: () -> Unit,
+        onSelectProgressBar: () -> Unit,
         onSelectStatus: () -> Unit,
         onSelectSwitch: () -> Unit,
         onSelectDivider: () -> Unit,
@@ -55,6 +56,8 @@ fun ComponentListScreen(
             ComponentRow("AvatarGroup", onClick = onSelectAvatarGroup)
             Divider()
             ComponentRow("Spinner", onClick = onSelectSpinner)
+            Divider()
+            ComponentRow("ProgressBar", onClick = onSelectProgressBar)
             Divider()
             ComponentRow("Status", onClick = onSelectStatus)
             Divider()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -8,6 +8,7 @@ data object TagPlaygroundKey
 data object AvatarPlaygroundKey
 data object AvatarGroupPlaygroundKey
 data object SpinnerPlaygroundKey
+data object ProgressBarPlaygroundKey
 data object StatusPlaygroundKey
 data object SwitchPlaygroundKey
 data object DividerPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/PlaygroundControls.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/PlaygroundControls.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.RadioButton
+import androidx.compose.material.Slider
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -16,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -72,5 +74,26 @@ internal fun BooleanControl(
     ) {
         Text(text = label, fontWeight = FontWeight.Bold)
         Switch(checked = value, onCheckedChange = onValueChange)
+    }
+}
+
+@Composable
+internal fun SliderControl(
+        label: String,
+        value: Int,
+        valueRange: IntRange,
+        onValueChange: (Int) -> Unit,
+) {
+    Column(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Text(text = "$label: $value", fontWeight = FontWeight.Bold)
+        Slider(
+                value = value.toFloat(),
+                onValueChange = { onValueChange(it.roundToInt()) },
+                valueRange = valueRange.first.toFloat()..valueRange.last.toFloat(),
+        )
     }
 }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ProgressBarPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ProgressBarPlaygroundScreen.kt
@@ -1,0 +1,83 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.ProgressBar
+import io.channel.bezier.v3.component.ProgressBarSize
+import io.channel.bezier.v3.component.ProgressBarVariant
+
+@Composable
+fun ProgressBarPlaygroundScreen(onBack: () -> Unit) {
+    var progress by remember { mutableStateOf(60) }
+    var size by remember { mutableStateOf(ProgressBarSize.Medium) }
+    var variant by remember { mutableStateOf(ProgressBarVariant.Default) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("ProgressBar") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                ProgressBar(
+                        modifier = Modifier.fillMaxWidth(),
+                        progress = progress,
+                        size = size,
+                        variant = variant,
+                )
+            }
+
+            Divider()
+
+            SliderControl("Progress", progress, 0..100) { progress = it }
+            EnumControl("Size", ProgressBarSize.values(), size) { size = it }
+            EnumControl("Variant", ProgressBarVariant.values(), variant) { variant = it }
+        }
+    }
+}


### PR DESCRIPTION
## 요약
Figma Mobile Components의 **ProgressBar**(선형 진행 바)를 v3 패키지에 신규 구현하고, sample 앱 playground에 추가했습니다.

## 컴포넌트 스펙 (Figma SSOT)
- **variant**: `default`(일반 배경 위, track `fillNeutralHeavy`) / `overlaid`(콘텐츠 위, track `fillGreyHeavier`)
- **size**: `medium`(높이 6dp) / `small`(높이 4dp), corner radius = height/2 (pill)
- **active fill**: `fillNeutralHeaviest` (variant 무관 동일)
- **progress**: `Int` `@IntRange(0..100)` — 레거시 `component.ProgressBar` 선례
- 텍스트·아이콘·보더 없음

## 구현 노트
- `drawBehind` + `drawRoundRect`로 track/fill을 직접 렌더 → 진행률 애니메이션(1000ms, `CubicBezierEasing(0.24f, 1f, 0.24f, 1f)`) 시 **recomposition/relayout 없이 redraw만** 수행
- width는 caller의 modifier가 결정 (레거시 계약 유지)

## 변경 파일
- `bezier/src/main/java/io/channel/bezier/v3/component/ProgressBar.kt` (신규)
- `sample/src/main/java/io/channel/bezier/compose/sample/playground/ProgressBarPlaygroundScreen.kt` (신규)
- `sample/.../playground/NavKeys.kt`, `ComponentListScreen.kt`, `PlaygroundControls.kt`, `MainActivity.kt` (playground 등록)

## 검증
- `:bezier:assembleDebug`, `:sample:assembleDebug` 빌드 성공
- Figma 대비 spec 검증(properties / layout / color / typography / asset) 및 구현 검증 통과

## 논의 필요
- **width 기본값**: 현재 caller가 width modifier를 안 주면 폭 0으로 렌더됨(레거시와 동일 계약). 컴포넌트에 `fillMaxWidth()` 기본을 넣어 컨테이너를 채우게 할지 검토 필요.
- **접근성**: `Modifier.progressSemantics()` 추가 여부 (Figma spec 미명시, 레거시도 미구현).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
