### PR TITLE
sample에 중첩 BottomSheet 데모 추가 (Holix / Material3)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activity-compose = "1.12.2"
 compose-bom = "2025.12.01"
 coil = "2.4.0"
 navigation3 = "1.1.2"
+bottomsheetdialogCompose = "1.6.0"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -26,10 +27,12 @@ ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 material = { group = "androidx.compose.material", name = "material" }
+material3 = { group = "androidx.compose.material3", name = "material3" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
 navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
+bottomsheetdialog-compose = { module = "com.holix.android:bottomsheetdialog-compose", version.ref = "bottomsheetdialogCompose" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     implementation(libs.ui.graphics)
     implementation(libs.ui.tooling.preview)
     implementation(libs.material)
+    implementation(libs.material3)
+    implementation(libs.bottomsheetdialog.compose)
     implementation(libs.navigation3.runtime)
     implementation(libs.navigation3.ui)
     testImplementation(libs.junit)

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -25,8 +25,12 @@ import io.channel.bezier.compose.sample.playground.ButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ComponentListKey
 import io.channel.bezier.compose.sample.playground.ComponentListScreen
+import io.channel.bezier.compose.sample.playground.HolixBottomSheetPlaygroundKey
+import io.channel.bezier.compose.sample.playground.HolixBottomSheetPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.MaterialBottomSheetPlaygroundKey
+import io.channel.bezier.compose.sample.playground.MaterialBottomSheetPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.StatusPlaygroundKey
@@ -68,6 +72,8 @@ private fun PlaygroundApp() {
                                     onSelectAvatarGroup = { backStack.add(AvatarGroupPlaygroundKey) },
                                     onSelectSpinner = { backStack.add(SpinnerPlaygroundKey) },
                                     onSelectStatus = { backStack.add(StatusPlaygroundKey) },
+                                    onSelectHolixBottomSheet = { backStack.add(HolixBottomSheetPlaygroundKey) },
+                                    onSelectMaterialBottomSheet = { backStack.add(MaterialBottomSheetPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -93,6 +99,12 @@ private fun PlaygroundApp() {
                         }
                         entry<StatusPlaygroundKey> {
                             StatusPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<HolixBottomSheetPlaygroundKey> {
+                            HolixBottomSheetPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<MaterialBottomSheetPlaygroundKey> {
+                            MaterialBottomSheetPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -25,6 +25,8 @@ fun ComponentListScreen(
         onSelectAvatarGroup: () -> Unit,
         onSelectSpinner: () -> Unit,
         onSelectStatus: () -> Unit,
+        onSelectHolixBottomSheet: () -> Unit,
+        onSelectMaterialBottomSheet: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -54,6 +56,10 @@ fun ComponentListScreen(
             ComponentRow("Spinner", onClick = onSelectSpinner)
             Divider()
             ComponentRow("Status", onClick = onSelectStatus)
+            Divider()
+            ComponentRow("Holix BottomSheet (중첩)", onClick = onSelectHolixBottomSheet)
+            Divider()
+            ComponentRow("Material BottomSheet (중첩)", onClick = onSelectMaterialBottomSheet)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/HolixBottomSheetPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/HolixBottomSheetPlaygroundScreen.kt
@@ -1,0 +1,107 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.holix.android.bottomsheetdialog.compose.BottomSheetDialog
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.Button
+import io.channel.bezier.v3.component.ButtonSemantic
+import io.channel.bezier.v3.component.ButtonVariant
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun HolixBottomSheetPlaygroundScreen(onBack: () -> Unit) {
+    var show by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Holix BottomSheet (중첩)") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("'바텀시트 하나 더 열기'를 누르면 Holix BottomSheetDialog가 계속 겹쳐서 쌓입니다.")
+            Button(
+                    text = "바텀시트 열기",
+                    onClick = { show = true },
+            )
+        }
+    }
+
+    if (show) {
+        HolixNestedBottomSheet(depth = 1, onDismiss = { show = false })
+    }
+}
+
+@Composable
+private fun HolixNestedBottomSheet(
+        depth: Int,
+        onDismiss: () -> Unit,
+) {
+    var showChild by remember { mutableStateOf(false) }
+
+    BottomSheetDialog(onDismissRequest = onDismiss) {
+        Surface {
+            Column(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text("Holix BottomSheet · depth $depth")
+                Button(
+                        text = "바텀시트 하나 더 열기",
+                        onClick = { showChild = true },
+                        modifier = Modifier.fillMaxWidth(),
+                )
+                Button(
+                        text = "닫기",
+                        onClick = onDismiss,
+                        modifier = Modifier.fillMaxWidth(),
+                        variant = ButtonVariant.Outlined,
+                        semantic = ButtonSemantic.Secondary,
+                )
+            }
+        }
+    }
+
+    if (showChild) {
+        HolixNestedBottomSheet(depth = depth + 1, onDismiss = { showChild = false })
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/MaterialBottomSheetPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/MaterialBottomSheetPlaygroundScreen.kt
@@ -1,0 +1,111 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.Button
+import io.channel.bezier.v3.component.ButtonSemantic
+import io.channel.bezier.v3.component.ButtonVariant
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun MaterialBottomSheetPlaygroundScreen(onBack: () -> Unit) {
+    var show by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Material BottomSheet (중첩)") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("'바텀시트 하나 더 열기'를 누르면 Material ModalBottomSheet가 계속 겹쳐서 쌓입니다.")
+            Button(
+                    text = "바텀시트 열기",
+                    onClick = { show = true },
+            )
+        }
+    }
+
+    if (show) {
+        MaterialNestedBottomSheet(depth = 1, onDismiss = { show = false })
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MaterialNestedBottomSheet(
+        depth: Int,
+        onDismiss: () -> Unit,
+) {
+    var showChild by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+            onDismissRequest = onDismiss,
+            sheetState = sheetState,
+    ) {
+        Column(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 24.dp, bottom = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text("Material ModalBottomSheet · depth $depth")
+            Button(
+                    text = "바텀시트 하나 더 열기",
+                    onClick = { showChild = true },
+                    modifier = Modifier.fillMaxWidth(),
+            )
+            Button(
+                    text = "닫기",
+                    onClick = onDismiss,
+                    modifier = Modifier.fillMaxWidth(),
+                    variant = ButtonVariant.Outlined,
+                    semantic = ButtonSemantic.Secondary,
+            )
+        }
+    }
+
+    if (showChild) {
+        MaterialNestedBottomSheet(depth = depth + 1, onDismiss = { showChild = false })
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -9,3 +9,5 @@ data object AvatarPlaygroundKey
 data object AvatarGroupPlaygroundKey
 data object SpinnerPlaygroundKey
 data object StatusPlaygroundKey
+data object HolixBottomSheetPlaygroundKey
+data object MaterialBottomSheetPlaygroundKey


### PR DESCRIPTION
## 요약
`sample` 앱에 **바텀시트 위에 바텀시트가 겹쳐 열리는** 중첩(nested) 데모 2종을 추가합니다. 두 바텀시트 구현체의 중첩 동작을 눈으로 비교하기 위함입니다.

| 항목 | 방식 | 중첩 원리 |
|---|---|---|
| Holix BottomSheet (중첩) | `com.holix.android:bottomsheetdialog-compose:1.6.0` 의 `BottomSheetDialog` (Dialog 방식) | 재귀 호출 시 각 시트가 별도 window로 겹쳐 쌓임 |
| Material BottomSheet (중첩) | `androidx.compose.material3` 의 `ModalBottomSheet` | 동일하게 별도 window로 겹쳐 쌓임 |

각 화면에서 "바텀시트 하나 더 열기"를 누르면 같은 종류의 시트가 `depth`를 쌓으며 계속 겹칩니다 (홀릭스→홀릭스, 메터리얼→메터리얼).

## 변경 사항
- `gradle/libs.versions.toml`, `sample/build.gradle.kts`: Holix `bottomsheetdialog-compose:1.6.0` + `material3` 의존성 추가
  - `ModalBottomSheet`는 material3 전용 API라 프로젝트에 material3를 신규 도입했습니다 (기존엔 material 구버전만 사용).
- 신규 화면 2개: `HolixBottomSheetPlaygroundScreen.kt`, `MaterialBottomSheetPlaygroundScreen.kt`
- `NavKeys.kt` / `MainActivity.kt` / `ComponentListScreen.kt`: navigation3 연결 + 컴포넌트 목록 항목 2개 추가
- 시트 내부 버튼은 bezier v3 `Button` 재사용

## 테스트
- `./gradlew :sample:assembleDebug` → BUILD SUCCESSFUL

MOB-6389

🤖 Generated with [Claude Code](https://claude.com/claude-code)