### PR TITLE
[MOB-6390] v3 Checkbox 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/extension/ModifierExtensions.kt
+++ b/bezier/src/main/java/io/channel/bezier/extension/ModifierExtensions.kt
@@ -13,9 +13,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -82,4 +89,27 @@ fun Modifier.shimmer(
                     end = Offset(x = translateAnimation.value, y = translateAnimation.value),
             ),
     )
+}
+
+fun Modifier.outsideBorder(
+        color: Color,
+        borderWidth: Dp,
+        shape: Shape,
+        gap: Dp = 0.dp,
+        stroke: Boolean = false,
+): Modifier = drawBehind {
+    val borderWidthPx = borderWidth.toPx()
+    val expandPx = gap.toPx() + borderWidthPx
+    val grownSize = Size(
+            width = size.width + expandPx * 2,
+            height = size.height + expandPx * 2,
+    )
+    val outline = shape.createOutline(grownSize, layoutDirection, this)
+    translate(left = -expandPx, top = -expandPx) {
+        drawOutline(
+                outline = outline,
+                color = color,
+                style = if (stroke) Stroke(width = borderWidthPx) else Fill,
+        )
+    }
 }

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Avatar.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Avatar.kt
@@ -14,12 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
@@ -29,6 +24,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
+import io.channel.bezier.extension.outsideBorder
 import io.channel.bezier.shape.SmoothRoundedCornerShape
 import io.channel.bezier.typography.BezierTypo
 
@@ -80,22 +76,6 @@ fun Avatar(
                     modifier = Modifier.offset(x = layout.statusOffsetX, y = layout.statusOffsetY),
             )
         }
-    }
-}
-
-private fun Modifier.outsideBorder(
-        color: Color,
-        borderWidth: Dp,
-        shape: Shape,
-) = drawBehind {
-    val borderWidthPx = borderWidth.toPx()
-    val grownSize = Size(
-            width = size.width + borderWidthPx * 2,
-            height = size.height + borderWidthPx * 2,
-    )
-    val outline = shape.createOutline(grownSize, layoutDirection, this)
-    translate(left = -borderWidthPx, top = -borderWidthPx) {
-        drawOutline(outline = outline, color = color)
     }
 }
 

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Checkbox.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Checkbox.kt
@@ -1,0 +1,197 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.color.BezierSemanticColorV3
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.extension.outsideBorder
+import io.channel.bezier.icon.CheckBold
+import io.channel.bezier.icon.HyphenBold
+import io.channel.bezier.typography.BezierTypo
+
+@Composable
+fun Checkbox(
+        checked: CheckboxState,
+        label: String,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        hasError: Boolean = false,
+) {
+    val colors = BezierTheme.colorsV3
+
+    Row(
+            modifier = modifier
+                    .graphicsLayer(alpha = if (enabled) 1f else 0.4f)
+                    .clickable(enabled = enabled, onClick = onClick)
+                    .padding(vertical = CheckboxRowVerticalPadding),
+            horizontalArrangement = Arrangement.spacedBy(CheckboxGap),
+            verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CheckboxIndicator(
+                checked = checked,
+                enabled = enabled,
+                showErrorRing = hasError && enabled,
+                colors = colors,
+        )
+        BezierText(
+                text = label,
+                typo = BezierTypo.TextXLarge,
+                color = colors.textNeutral,
+        )
+    }
+}
+
+@Composable
+private fun CheckboxIndicator(
+        checked: CheckboxState,
+        enabled: Boolean,
+        showErrorRing: Boolean,
+        colors: BezierSemanticColorV3,
+) {
+    val errorBorderModifier = if (showErrorRing) {
+        Modifier.outsideBorder(
+                color = colors.stateWarning,
+                borderWidth = CheckboxRingBorderWidth,
+                shape = RoundedCornerShape(CheckboxRingRadius),
+                gap = CheckboxRingGap,
+                stroke = true,
+        )
+    } else {
+        Modifier
+    }
+
+    Box(
+            modifier = Modifier
+                    .then(errorBorderModifier)
+                    .size(CheckboxBoxSize)
+                    .clip(RoundedCornerShape(CheckboxBoxRadius))
+                    .background(checked.background(colors, enabled))
+                    .then(
+                            if (checked == CheckboxState.Unchecked) {
+                                Modifier.border(
+                                        width = CheckboxBorderWidth,
+                                        color = colors.borderNeutralHeavy,
+                                        shape = RoundedCornerShape(CheckboxBoxRadius),
+                                )
+                            } else {
+                                Modifier
+                            },
+                    ),
+            contentAlignment = Alignment.Center,
+    ) {
+        val icon = checked.icon
+        if (icon != null) {
+            Icon(
+                    modifier = Modifier.size(CheckboxIconSize),
+                    imageVector = icon.imageVector,
+                    tint = colors.iconInverseHeavier,
+                    contentDescription = null,
+            )
+        }
+    }
+}
+
+enum class CheckboxState {
+    Unchecked,
+    Checked,
+    Indeterminate;
+
+    internal fun background(colors: BezierSemanticColorV3, enabled: Boolean): Color = when (this) {
+        Unchecked -> if (enabled) colors.fillGreyLight else colors.fillNeutralHeavy
+        Checked, Indeterminate -> colors.fillNeutralHeaviest
+    }
+
+    internal val icon: BezierIcon?
+        get() = when (this) {
+            Unchecked -> null
+            Checked -> BezierIcons.CheckBold
+            Indeterminate -> BezierIcons.HyphenBold
+        }
+}
+
+private val CheckboxGap: Dp = 8.dp
+private val CheckboxRowVerticalPadding: Dp = 8.dp
+private val CheckboxBoxSize: Dp = 22.dp
+private val CheckboxBoxRadius: Dp = 10.dp
+private val CheckboxBorderWidth: Dp = 2.dp
+private val CheckboxIconSize: Dp = 18.dp
+private val CheckboxRingGap: Dp = 1.5.dp
+private val CheckboxRingRadius: Dp = 13.dp
+private val CheckboxRingBorderWidth: Dp = 1.5.dp
+
+@Preview(showBackground = true, widthDp = 640)
+@Preview(showBackground = true, widthDp = 640, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun CheckboxMatrixPreview() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(modifier = Modifier.size(width = 140.dp, height = 40.dp))
+                listOf("default", "error", "disabled").forEach { stateLabel ->
+                    Box(
+                            modifier = Modifier.size(width = 160.dp, height = 40.dp),
+                            contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BezierText(
+                                text = stateLabel,
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                }
+            }
+
+            CheckboxState.entries.forEach { state ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                            modifier = Modifier.size(width = 140.dp, height = 40.dp),
+                            contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BezierText(
+                                text = state.name,
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                    }
+                    Box(modifier = Modifier.size(width = 160.dp, height = 40.dp)) {
+                        Checkbox(checked = state, label = "Label", onClick = {})
+                    }
+                    Box(modifier = Modifier.size(width = 160.dp, height = 40.dp)) {
+                        Checkbox(checked = state, label = "Label", onClick = {}, hasError = true)
+                    }
+                    Box(modifier = Modifier.size(width = 160.dp, height = 40.dp)) {
+                        Checkbox(checked = state, label = "Label", onClick = {}, enabled = false)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 요약
Figma Checkbox 컴포넌트를 bezier v3 패키지에 신규 구현했습니다.

## Figma
- [🚧 Mobile Components — Checkbox](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4838-126&m=dev) (node `4838:126`)

## 변경
- `v3/component/Checkbox.kt` (신규)
- `extension/ModifierExtensions.kt` (`outsideBorder` 공통 확장 추가)
- `v3/component/Avatar.kt` (private `outsideBorder` 제거 → 공통 함수 사용)

## 구현
- Variant: `checked`(unchecked / checked / indeterminate) × `state`(default / disabled) × `hasError`(false / true), 총 9 조합
- v3 컬러 토큰(`BezierTheme.colorsV3`)만 사용, 아이콘 `BezierIcons.CheckBold` / `BezierIcons.HyphenBold`
- API: `Checkbox(checked: CheckboxState, label, onClick, modifier, enabled, hasError)` — `checked` 단일 축 enum, `state=disabled`는 `enabled: Boolean`으로 매핑
- disabled: 컨테이너 `graphicsLayer(alpha = 0.4)`
- 에러 보더: `stateWarning`, `hasError && enabled`일 때만. Avatar와 동일한 `outsideBorder`(`drawBehind`) 방식

## 리팩터
- `outsideBorder`를 `io.channel.bezier.extension`(ModifierExtensions.kt) 공통 Modifier 확장으로 추가하고 Avatar에 있던 중복 제거
- `gap` / `stroke` 파라미터로 fill(Avatar 경계선)·stroke(Checkbox 에러 링) 두 용도를 한 함수로 커버

## 검증
- Figma SSOT 대조(Properties / Layout / Color / Typography / Asset) 완료
- `./gradlew :bezier:assembleDebug` → **BUILD SUCCESSFUL**

## 티켓
MOB-6390

🤖 Generated with [Claude Code](https://claude.com/claude-code)