### PR TITLE
[MOB-6391] v3 Banner 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Banner.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Banner.kt
@@ -1,0 +1,292 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.Block
+import io.channel.bezier.icon.CancelSmall
+import io.channel.bezier.icon.CheckCircleFilled
+import io.channel.bezier.icon.ChevronSmallRight
+import io.channel.bezier.icon.ErrorDiamondFilled
+import io.channel.bezier.icon.Info
+import io.channel.bezier.icon.Lightbulb
+import io.channel.bezier.icon.Limit
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+@Composable
+fun Banner(
+        description: String,
+        modifier: Modifier = Modifier,
+        color: BannerColor = BannerColor.Default,
+        title: String? = null,
+        leadingIcon: BezierIcon? = color.defaultIcon,
+        onClick: (() -> Unit)? = null,
+        onDismiss: (() -> Unit)? = null,
+) {
+    val colorSpec = bannerColorSpec(color)
+    val trailingIcon = when {
+        onDismiss != null -> BezierIcons.CancelSmall
+        onClick != null -> BezierIcons.ChevronSmallRight
+        else -> null
+    }
+
+    Row(
+            modifier = modifier
+                    .clip(RoundedCornerShape(BannerCornerRadius))
+                    .background(colorSpec.background)
+                    .then(
+                            if (onClick != null) {
+                                Modifier.clickable(onClick = onClick)
+                            } else {
+                                Modifier
+                            }
+                    )
+                    .padding(BannerContainerPadding),
+            verticalAlignment = Alignment.Top,
+    ) {
+        if (leadingIcon != null) {
+            Box(modifier = Modifier.padding(BannerLeadingIconPadding)) {
+                Icon(
+                        modifier = Modifier.size(BannerIconLength),
+                        imageVector = leadingIcon.imageVector,
+                        tint = colorSpec.iconColor,
+                        contentDescription = null,
+                )
+            }
+        }
+
+        Column(
+                modifier = Modifier
+                        .weight(1f)
+                        .padding(BannerContentPadding),
+                verticalArrangement = Arrangement.spacedBy(BannerContentGap),
+        ) {
+            if (title != null) {
+                BezierText(
+                        text = title,
+                        typo = BezierTypo.TextMedium,
+                        weight = BezierWeight.Bold,
+                        color = colorSpec.textColor,
+                )
+            }
+            BezierText(
+                    text = description,
+                    typo = BezierTypo.TextMedium,
+                    weight = BezierWeight.Regular,
+                    color = colorSpec.textColor,
+            )
+        }
+
+        if (trailingIcon != null) {
+            Box(
+                    modifier = Modifier
+                            .size(BannerTrailingSlotLength)
+                            .then(
+                                    if (onDismiss != null) {
+                                        Modifier
+                                                .clip(CircleShape)
+                                                .clickable(onClick = onDismiss)
+                                    } else {
+                                        Modifier
+                                    }
+                            )
+                            .padding(BannerTrailingSlotPadding),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                        modifier = Modifier.size(BannerIconLength),
+                        imageVector = trailingIcon.imageVector,
+                        tint = colorSpec.iconColor,
+                        contentDescription = null,
+                )
+            }
+        }
+    }
+}
+
+private val BannerCornerRadius: Dp = 16.dp
+private val BannerContainerPadding = PaddingValues(horizontal = 8.dp, vertical = 10.dp)
+private val BannerLeadingIconPadding = PaddingValues(start = 4.dp, end = 2.dp, top = 5.dp, bottom = 5.dp)
+private val BannerContentPadding = PaddingValues(6.dp)
+private val BannerContentGap: Dp = 4.dp
+private val BannerTrailingSlotLength: Dp = 30.dp
+private val BannerTrailingSlotPadding = PaddingValues(5.dp)
+private val BannerIconLength: Dp = 20.dp
+
+enum class BannerColor {
+    Default,
+    Blue,
+    Cobalt,
+    Green,
+    Orange,
+    Red;
+
+    internal val defaultIcon: BezierIcon
+        get() = when (this) {
+            Default -> BezierIcons.Info
+            Blue -> BezierIcons.Limit
+            Cobalt -> BezierIcons.Lightbulb
+            Green -> BezierIcons.CheckCircleFilled
+            Orange -> BezierIcons.ErrorDiamondFilled
+            Red -> BezierIcons.Block
+        }
+}
+
+internal data class BannerColorSpec(
+        val background: Color,
+        val textColor: Color,
+        val iconColor: Color,
+)
+
+@Composable
+internal fun bannerColorSpec(color: BannerColor): BannerColorSpec {
+    val colors = BezierTheme.colorsV3
+    return when (color) {
+        BannerColor.Default -> BannerColorSpec(
+                background = colors.fillNeutralLighter,
+                textColor = colors.textNeutralLight,
+                iconColor = colors.iconNeutral,
+        )
+
+        BannerColor.Blue -> BannerColorSpec(
+                background = colors.fillAccentBlue,
+                textColor = colors.textAccentBlue,
+                iconColor = colors.iconAccentBlue,
+        )
+
+        BannerColor.Cobalt -> BannerColorSpec(
+                background = colors.fillAccentCobalt,
+                textColor = colors.textAccentCobalt,
+                iconColor = colors.iconAccentCobalt,
+        )
+
+        BannerColor.Green -> BannerColorSpec(
+                background = colors.fillAccentGreen,
+                textColor = colors.textAccentGreen,
+                iconColor = colors.iconAccentGreen,
+        )
+
+        BannerColor.Orange -> BannerColorSpec(
+                background = colors.fillAccentOrange,
+                textColor = colors.textAccentOrange,
+                iconColor = colors.iconAccentOrange,
+        )
+
+        BannerColor.Red -> BannerColorSpec(
+                background = colors.fillAccentRed,
+                textColor = colors.textAccentRed,
+                iconColor = colors.iconAccentRed,
+        )
+    }
+}
+
+@Composable
+private fun BannerMatrix() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            BannerColor.values().forEach { color ->
+                Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.Top,
+                ) {
+                    Banner(
+                            modifier = Modifier.width(320.dp),
+                            title = "Banner Title",
+                            description = "Banner description text goes here.",
+                            color = color,
+                    )
+                    Banner(
+                            modifier = Modifier.width(320.dp),
+                            title = "Banner Title",
+                            description = "Banner description text goes here.",
+                            color = color,
+                            onClick = {},
+                    )
+                    Banner(
+                            modifier = Modifier.width(320.dp),
+                            title = "Banner Title",
+                            description = "Banner description text goes here.",
+                            color = color,
+                            onDismiss = {},
+                    )
+                    Banner(
+                            modifier = Modifier.width(320.dp),
+                            title = "Banner Title",
+                            description = "Banner description text goes here.",
+                            color = color,
+                            onClick = {},
+                            onDismiss = {},
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BannerVariantMatrix() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            BannerColor.values().forEach { color ->
+                Banner(
+                        modifier = Modifier.width(320.dp),
+                        description = "Banner description text goes here.",
+                        color = color,
+                )
+                Banner(
+                        modifier = Modifier.width(320.dp),
+                        title = "Banner Title",
+                        description = "Banner description text goes here.",
+                        color = color,
+                        leadingIcon = null,
+                        onClick = {},
+                        onDismiss = {},
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 1400)
+@Preview(showBackground = true, widthDp = 1400, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun BannerMatrixPreview() = BannerMatrix()
+
+@Preview(showBackground = true, widthDp = 400)
+@Preview(showBackground = true, widthDp = 400, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun BannerVariantMatrixPreview() = BannerVariantMatrix()


### PR DESCRIPTION
## 요약
Bezier Mobile Components 의 **Banner** 컴포넌트를 v3 패키지(`io.channel.bezier.v3.component`)에 구현합니다. Toast 와 달리 자동 소멸하지 않는 지속적 메시지 컴포넌트(Inner 전용)입니다.

## 변경
- `bezier/src/main/java/io/channel/bezier/v3/component/Banner.kt` — Compose 구현

## 구성
- **variant** 6색: default / blue / cobalt / green / orange / red
- **클릭 이벤트 2개로 분리** (X 닫기와 배너 클릭을 구분):
  | `onClick` | `onDismiss` | 동작 |
  |---|---|---|
  | — | — | 정적 |
  | ✓ | — | 배너 전체 탭 + chevron 표시 |
  | — | ✓ | X(cancel) 표시, X만 탭 → 닫기 |
  | ✓ | ✓ | X 표시 + 배너 전체 탭. 자식 clickable이 X 탭을 먼저 소비해 이벤트가 구분됨 |
- **leadingIcon**: variant별 프리셋(Info/Limit/Lightbulb/CheckCircleFilled/ErrorDiamondFilled/Block), `null` 로 숨김·교체 가능
- **hasTitle**(`title`) / **description**
- v3 컬러 토큰만 사용 — accent 배경 `fillAccent{X}`(alpha 0.1, Badge 의 Heavy 아님), text/icon 분리 토큰
- API·프리뷰는 Badge.kt / Tag.kt(`onDelete`) 관례 준용

## 검증
- `:bezier:compileDebugKotlin` **BUILD SUCCESSFUL**

## 링크
- Linear: [MOB-6391](https://linear.app/channel/issue/MOB-6391/v3-banner-컴포넌트-구현) (부모: MOB-6369)
- Figma: [Mobile Components — Banner](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1121-30&m=dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)