### PR TITLE
[MOB-6413] v3 TextArea 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/color/ColorsV3.kt
+++ b/bezier/src/main/java/io/channel/bezier/color/ColorsV3.kt
@@ -131,6 +131,7 @@ interface BezierSemanticColorV3 {
     val iconWarning: Color
     val stateAction: Color
     val stateActionLight: Color
+    val stateActive: Color
     val stateDefault: Color
     val stateWarning: Color
     val stateWarningLight: Color
@@ -298,6 +299,7 @@ internal class LightColor : BezierSemanticColorV3 {
     override val iconWarning = BezierGlobalColor.Orange400
     override val stateAction = BezierGlobalColor.Blue400
     override val stateActionLight = BezierGlobalColor.Blue400_30
+    override val stateActive = BezierGlobalColor.Black85
     override val stateDefault = BezierGlobalColor.Black15
     override val stateWarning = BezierGlobalColor.Orange400
     override val stateWarningLight = BezierGlobalColor.Orange400_30
@@ -464,6 +466,7 @@ internal class DarkColor : BezierSemanticColorV3 {
     override val iconWarning = BezierGlobalColor.Orange300
     override val stateAction = BezierGlobalColor.Blue300
     override val stateActionLight = BezierGlobalColor.Blue300_45
+    override val stateActive = BezierGlobalColor.White80
     override val stateDefault = BezierGlobalColor.White20
     override val stateWarning = BezierGlobalColor.Orange300
     override val stateWarningLight = BezierGlobalColor.Orange300

--- a/bezier/src/main/java/io/channel/bezier/v3/component/TextArea.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/TextArea.kt
@@ -1,0 +1,187 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.color.BezierSemanticColorV3
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.typography.BezierTypo
+
+@Composable
+fun TextArea(
+        value: String,
+        onValueChange: (String) -> Unit,
+        modifier: Modifier = Modifier,
+        placeholder: String = "",
+        enabled: Boolean = true,
+        readOnly: Boolean = false,
+        hasError: Boolean = false,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = BezierTheme.colorsV3
+    val focused by interactionSource.collectIsFocusedAsState()
+
+    val state = when {
+        !enabled -> TextAreaState.Disabled
+        readOnly -> TextAreaState.ReadOnly
+        hasError -> TextAreaState.Error
+        focused -> TextAreaState.Focused
+        else -> TextAreaState.Default
+    }
+
+    BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier
+                    .fillMaxWidth()
+                    .widthIn(min = TextAreaMinWidth)
+                    .graphicsLayer(alpha = if (enabled) 1f else TextAreaDisabledAlpha),
+            enabled = enabled,
+            readOnly = readOnly,
+            textStyle = TextStyle(
+                    fontSize = BezierTypo.TextXLarge.fontSize,
+                    lineHeight = BezierTypo.TextXLarge.lineHeight,
+                    letterSpacing = BezierTypo.TextXLarge.letterSpacing,
+                    fontWeight = FontWeight.Normal,
+                    color = state.valueTextColor(colors),
+            ),
+            cursorBrush = SolidColor(colors.textNeutral),
+            interactionSource = interactionSource,
+            decorationBox = { innerTextField ->
+                Box(
+                        modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = TextAreaMinHeight, max = TextAreaMaxHeight)
+                                .clip(RoundedCornerShape(TextAreaRadius))
+                                .background(state.background(colors))
+                                .border(
+                                        width = TextAreaBorderWidth,
+                                        color = state.border(colors),
+                                        shape = RoundedCornerShape(TextAreaRadius),
+                                )
+                                .padding(horizontal = TextAreaHorizontalPadding, vertical = TextAreaVerticalPadding),
+                ) {
+                    if (value.isEmpty()) {
+                        BezierText(
+                                text = placeholder,
+                                typo = BezierTypo.TextXLarge,
+                                color = colors.textNeutralLighter,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+    )
+}
+
+private enum class TextAreaState {
+    Default,
+    Focused,
+    Error,
+    ReadOnly,
+    Disabled;
+
+    fun background(colors: BezierSemanticColorV3): Color = when (this) {
+        Default, Disabled -> colors.fillGrey
+        Focused, Error -> colors.fillGreyLight
+        ReadOnly -> colors.fillGreyHeavy
+    }
+
+    fun border(colors: BezierSemanticColorV3): Color = when (this) {
+        Focused -> colors.stateActive
+        Error -> colors.stateWarning
+        Default, ReadOnly, Disabled -> colors.stateDefault
+    }
+
+    fun valueTextColor(colors: BezierSemanticColorV3): Color = when (this) {
+        ReadOnly -> colors.textNeutralLight
+        Default, Focused, Error, Disabled -> colors.textNeutral
+    }
+}
+
+private val TextAreaMinWidth: Dp = 40.dp
+private val TextAreaMinHeight: Dp = 64.dp
+private val TextAreaMaxHeight: Dp = 160.dp
+private val TextAreaRadius: Dp = 12.dp
+private val TextAreaBorderWidth: Dp = 1.5.dp
+private val TextAreaHorizontalPadding: Dp = 10.dp
+private val TextAreaVerticalPadding: Dp = 8.dp
+private const val TextAreaDisabledAlpha: Float = 0.4f
+
+@Preview(showBackground = true, widthDp = 940)
+@Preview(showBackground = true, widthDp = 940, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun TextAreaMatrixPreview() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            listOf(false, true).forEach { hasValue ->
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    TextAreaPreviewCell("default", hasValue)
+                    TextAreaPreviewCell("error", hasValue, hasError = true)
+                    TextAreaPreviewCell("readOnly", hasValue, readOnly = true)
+                    TextAreaPreviewCell("disabled", hasValue, enabled = false)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextAreaPreviewCell(
+        label: String,
+        hasValue: Boolean,
+        enabled: Boolean = true,
+        readOnly: Boolean = false,
+        hasError: Boolean = false,
+) {
+    Column(
+            modifier = Modifier.width(200.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        BezierText(
+                text = label,
+                typo = BezierTypo.TextMedium,
+                color = BezierTheme.colorsV3.textNeutralLight,
+        )
+        TextArea(
+                value = if (hasValue) "Sample text" else "",
+                onValueChange = {},
+                placeholder = "Placeholder",
+                enabled = enabled,
+                readOnly = readOnly,
+                hasError = hasError,
+        )
+    }
+}

--- a/docs/components/TextArea/SPEC.md
+++ b/docs/components/TextArea/SPEC.md
@@ -1,0 +1,138 @@
+# TextArea Spec
+
+> Figma: [🚧 Mobile-Components](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1850-13&m=dev)
+> Design spec doc: https://github.com/channel-io/team-design/blob/main/bezier-v3/components/TextArea-spec.md
+
+여러 줄 텍스트를 작성하는 입력 영역. 설명, 메모, 답변 템플릿 등에 사용.
+
+- **모양**: 사각형 (radius 12)
+- **Accessibility**: hasError 사용 시 반드시 에러 메시지를 함께 표시할 것 (빨간 테두리만 표시 금지)
+- **인접 배치**: 한 줄 입력(이름·이메일 등)에는 TextInput을 사용
+
+---
+
+## 1. Component Properties
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **state** | `default` / `focused` / `error` / `readOnly` / `disabled` | Figma 설계용 |
+| **hasValue** | `false` / `true` | 값 유무 상태 시각 확인용 |
+
+총 instance: `5 × 2 = 10개`
+
+---
+
+## 2. Layout Spec
+
+| 항목 | 값 |
+|---|---|
+| width | fill (min-width 40) |
+| min-height | 64 |
+| max-height | 160 |
+| padding horizontal | 10 |
+| padding vertical | 8 |
+| corner radius | 12 |
+| border width | 1.5 (inset) |
+| overflow | clip |
+
+- 단위는 Android 관용에 따라 `dp`
+- min-height 64 = 2행, max-height 160 = 6행 (line-height 24 기준)
+- border는 inset stroke (inner shadow spread 1.5px)
+
+---
+
+## 3. State 별 컬러 토큰
+
+### Background
+
+| State | Background | Figma Variable | Raw |
+|---|---|---|---|
+| `default` | `fillGrey` | `color/fill/grey` | `#fbfbfb` |
+| `focused` | `fillGreyLight` | `color/fill/grey/light` | `#fdfdfd` |
+| `error` | `fillGreyLight` | `color/fill/grey/light` | `#fdfdfd` |
+| `readOnly` | `fillGreyHeavy` | `color/fill/grey/heavy` | `#f7f7f8` |
+| `disabled` | `fillGrey` | `color/fill/grey` | `#fbfbfb` |
+
+### Border
+
+| State | Border | Figma Variable | Raw |
+|---|---|---|---|
+| `default` | `stateDefault` | `color/state/default` | `#00000026` |
+| `focused` | `stateActive` | `color/state/active` | `#000000d9` |
+| `error` | `stateWarning` | `color/state/warning` | `#e67f2b` |
+| `readOnly` | `stateDefault` | `color/state/default` | `#00000026` |
+| `disabled` | `stateDefault` | `color/state/default` | `#00000026` |
+
+### Text color
+
+| State | hasValue | Text | Figma Variable | Raw |
+|---|---|---|---|---|
+| 전체 | `false` (placeholder) | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| `default` · `focused` · `error` · `disabled` | `true` | `textNeutral` | `color/text/neutral` | `#000000d9` |
+| `readOnly` | `true` | `textNeutralLight` | `color/text/neutral/light` | `#00000099` |
+
+---
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 |
+|---|---|---|
+| placeholder / value | `BezierTypo.TextXLarge` | `Typography/text/xlarge` |
+
+`text/xlarge`: Inter / size 16 / weight regular(400) / line-height 24 / letter-spacing tight(-0.1)
+
+---
+
+## 5. State 별 시각 동작
+
+| State | Background | Border | Value Text | Interaction |
+|---|---|---|---|---|
+| `default` | `fillGrey` | `stateDefault` | `textNeutral` | 입력 가능 |
+| `focused` | `fillGreyLight` | `stateActive` | `textNeutral` | 포커스 (입력 중) |
+| `error` | `fillGreyLight` | `stateWarning` | `textNeutral` | 입력 가능 |
+| `readOnly` | `fillGreyHeavy` | `stateDefault` | `textNeutralLight` | 읽기 전용 |
+| `disabled` | `fillGrey` | `stateDefault` | `textNeutral` | 비활성 (opacity 0.4) |
+
+- placeholder(hasValue=false) 텍스트는 state와 무관하게 `textNeutralLighter`
+- `disabled`는 컨테이너 전체 opacity 0.4
+
+---
+
+## 6. 디자이너 가이드라인 (Figma 컴포넌트 description 인용)
+
+- width: 기본 fill(부모 폭 채움). 최소 너비 40px
+- 모바일 기본 높이 64px(2행) / 최대 160px(6행) (line-height 24px 기준)
+- hasError 사용 시 반드시 에러 메시지를 함께 표시할 것 (빨간 테두리만 표시 금지)
+- 한 줄 입력(이름·이메일 등)에는 TextInput을 사용
+
+---
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| Compose 구현 | `bezier/src/main/java/io/channel/bezier/v3/component/TextArea.kt` (`@Composable fun TextArea(...)`) |
+| 컬러 토큰 | `BezierTheme.colorsV3.tokenName` (`BezierSemanticColorV3` 멤버) |
+| 신규 컬러 토큰 | `stateActive` (`BezierSemanticColorV3` 신규 추가 대상) |
+| Typography 토큰 | `BezierTypo.TextXLarge` |
+
+---
+
+## 8. Variant 매트릭스
+
+총 instance: `5 × 2 = 10개`
+
+```
+state=default,  hasValue=false = 1850:3
+state=focused,  hasValue=false = 1850:5
+state=error,    hasValue=false = 1850:7
+state=readOnly, hasValue=false = 1850:9
+state=disabled, hasValue=false = 1850:11
+state=default,  hasValue=true  = 4542:66
+state=focused,  hasValue=true  = 4542:68
+state=error,    hasValue=true  = 4542:70
+state=readOnly, hasValue=true  = 4542:72
+state=disabled, hasValue=true  = 4542:74
+```


### PR DESCRIPTION
## 개요

Bezier Mobile Components 의 TextArea(v3)를 `io.channel.bezier.v3.component` 패키지에 구현.

- Linear: [MOB-6413](https://linear.app/channel/issue/MOB-6413/v3-textarea-컴포넌트-구현)
- Figma: [TextArea (node 1850-13)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1850-13&m=dev)

## 변경

- `v3/component/TextArea.kt` 신규 — `TextArea(value, onValueChange, placeholder, enabled, readOnly, hasError)`
  - state 5종(default / focused / error / readOnly / disabled) × hasValue = 10 조합
  - focused는 내부 `interactionSource`, 나머지는 파라미터 주입. 우선순위 disabled > readOnly > error > focused > default
  - state별 background/border/valueTextColor를 `TextAreaState` enum 으로 분리
- `color/ColorsV3.kt` — 신규 토큰 `stateActive`(`color/state/active`) 추가: Light `Black85` / Dark `White80`

## 컬러 (v3 토큰만)

- background: `fillGrey` / `fillGreyLight` / `fillGreyHeavy`
- border(inset 1.5): `stateDefault` / `stateActive` / `stateWarning`
- text: `textNeutral`(값) / `textNeutralLighter`(placeholder) / `textNeutralLight`(readOnly 값)
- 타이포: `BezierTypo.TextXLarge`

## 검증

- `figma-component-spec` 파이프라인 — Spec 검증 7차원 + 구현 검증 전 항목 통과
- `readOnly` × `hasValue=true` 값 텍스트가 `textNeutralLight`(#00000099)임을 Figma SSOT로 반영
- `:bezier:compileDebugKotlin` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)