### PR TITLE
[MOB-6415] v3 BottomSheetContent 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/BottomSheetContent.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/BottomSheetContent.kt
@@ -1,0 +1,205 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.typography.BezierTypo
+
+@Composable
+fun BottomSheetContent(
+        modifier: Modifier = Modifier,
+        title: String? = null,
+        description: String? = null,
+        showGrabber: Boolean = false,
+        content: @Composable () -> Unit,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (showGrabber) {
+            BottomSheetContentGrabber()
+        }
+
+        if (title != null) {
+            BottomSheetContentHeader(
+                    title = title,
+                    description = description,
+            )
+        }
+
+        Column(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                                top = ContentTopPadding,
+                                start = ContentHorizontalPadding,
+                                end = ContentHorizontalPadding,
+                        ),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetContentGrabber() {
+    Column(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = GrabberTopPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+                modifier = Modifier
+                        .size(width = GrabberWidth, height = GrabberHeight)
+                        .clip(RoundedCornerShape(GrabberCornerRadius))
+                        .background(BezierTheme.colorsV3.fillNeutralHeavy),
+        )
+    }
+}
+
+@Composable
+private fun BottomSheetContentHeader(
+        title: String,
+        description: String?,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Column(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                                top = HeaderTopPadding,
+                                bottom = HeaderBottomPadding,
+                                start = HeaderHorizontalPadding,
+                                end = HeaderHorizontalPadding,
+                        ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(HeaderItemSpacing),
+        ) {
+            BezierText(
+                    text = title,
+                    typo = BezierTypo.HeadingSmall,
+                    modifier = Modifier.fillMaxWidth(),
+                    color = BezierTheme.colorsV3.textNeutral,
+                    textAlign = TextAlign.Center,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = TitleMaxLines,
+            )
+
+            if (description != null) {
+                BezierText(
+                        text = description,
+                        typo = BezierTypo.CaptionMedium,
+                        modifier = Modifier.fillMaxWidth(),
+                        color = BezierTheme.colorsV3.textNeutralLighter,
+                        textAlign = TextAlign.Center,
+                )
+            }
+        }
+
+        Divider(
+                sideIndent = false,
+                parallelIndent = false,
+        )
+    }
+}
+
+private val GrabberTopPadding: Dp = 5.dp
+private val GrabberWidth: Dp = 36.dp
+private val GrabberHeight: Dp = 5.dp
+private val GrabberCornerRadius: Dp = 100.dp
+private val HeaderTopPadding: Dp = 18.dp
+private val HeaderBottomPadding: Dp = 16.dp
+private val HeaderHorizontalPadding: Dp = 24.dp
+private val HeaderItemSpacing: Dp = 4.dp
+private val ContentTopPadding: Dp = 12.dp
+private val ContentHorizontalPadding: Dp = 10.dp
+private const val TitleMaxLines: Int = 2
+
+@Composable
+private fun BottomSheetContentPreviewContent() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            BottomSheetContentPreviewSurface {
+                BottomSheetContent(
+                        title = "Title",
+                        description = "Description",
+                        showGrabber = true,
+                ) {
+                    BottomSheetContentPreviewBody()
+                }
+            }
+
+            BottomSheetContentPreviewSurface {
+                BottomSheetContent(title = "Title") {
+                    BottomSheetContentPreviewBody()
+                }
+            }
+
+            BottomSheetContentPreviewSurface {
+                BottomSheetContent(showGrabber = true) {
+                    BottomSheetContentPreviewBody()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetContentPreviewSurface(content: @Composable () -> Unit) {
+    Box(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
+                    .background(BezierTheme.colorsV3.surface),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun BottomSheetContentPreviewBody() {
+    Box(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .height(96.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(BezierTheme.colorsV3.surfaceLow),
+    ) {
+        BezierText(
+                text = "content",
+                typo = BezierTypo.TextMedium,
+                modifier = Modifier.padding(16.dp),
+                color = BezierTheme.colorsV3.textNeutral,
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+private fun BottomSheetContentPreview() = BottomSheetContentPreviewContent()
+
+@Preview(showBackground = true, widthDp = 360, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun BottomSheetContentDarkPreview() = BottomSheetContentPreviewContent()

--- a/docs/components/BottomSheetContent/SPEC.md
+++ b/docs/components/BottomSheetContent/SPEC.md
@@ -1,0 +1,102 @@
+# BottomSheetContent Spec
+
+> Figma: [🚧 Mobile Components — BottomSheet](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5105-11844&m=dev)
+> Figma component node ID: `1306:200` (BottomSheet) / 예시 instance `5105:11844`
+> Design spec doc: [channel-io/design-team — BottomSheet-spec.md](https://github.com/channel-io/design-team/blob/main/docs/bezier-v3/component-spec/BottomSheet-spec.md)
+
+바텀시트 Surface 내부에 들어가는 컨텐츠 래퍼. Grabber + Header + content 슬롯으로 구성.
+
+- **스코프**: 이 컴포넌트는 `BottomSheetContent` — Surface 내부 컨텐츠만 담당한다. Backdrop, Surface 컨테이너(배경/모서리/그림자), 하단 정렬, 드래그, 슬라이드 애니메이션은 실제 바텀시트 컴포넌트가 담당하며 별도로 래핑한다.
+- **Figma → 스코프 매핑**: Figma `BottomSheet`(1306:200) = `Backdrop` + `Surface(Grabber + Header + contentWrapper)`. 이 중 `Surface` 내부(`Grabber`, `Header`, `contentWrapper`)만 구현. `Backdrop`, `Surface` 자체 스타일은 제외.
+
+---
+
+## 1. Component Properties
+
+Figma `BottomSheet`(1306:200) component property는 다음이 전부다.
+
+| Property | 값 | 기본값 | 비고 |
+|---|---|---|---|
+| **hasHeader** | boolean | `false` | Header(타이틀 + Divider) 표시 여부 |
+| **showGrabber** | boolean | `false` | 최상단 Grabber 표시 여부. content가 스크롤될 만큼 길 때만 true |
+
+Header 내부 nested property (`Internal/BottomSheetHeader` 1293:121):
+
+| Property | 값 | 기본값 | 비고 |
+|---|---|---|---|
+| **title** | text | `"Title"` | 타이틀 텍스트 |
+| **hasDescription** | boolean | `false` | 보조 설명 표시 여부. Figma `Internal/BottomSheetHeader`(1293:121) description: "true(보조 설명 추가 - 확인성 시트에서만 사용)" |
+| **description** | text | `"Description"` | `hasDescription = true`일 때 표시할 설명 텍스트 |
+
+content 슬롯: `contentWrapper > content` (1306:204) — 임의 UI 배치.
+
+---
+
+## 2. Layout / 구조
+
+단위는 Android 관용에 따라 `dp` (텍스트는 `sp`).
+
+Root: `Column`, `fillMaxWidth`. 배경/모서리/그림자 없음 (Surface = 시트 담당).
+
+배치 순서 (위 → 아래):
+
+1. **Grabber** — `showGrabber = true`일 때만
+2. **Header** — `hasHeader = true`일 때만
+3. **contentWrapper** — 항상
+
+### 2-1. Grabber (`showGrabber`)
+
+| 요소 | 값 |
+|---|---|
+| Wrapper | `Column`, 가로 중앙 정렬, `paddingTop = 5`, `fillMaxWidth` |
+| Bar | `width = 36`, `height = 5`, corner radius `100` (완전 알약형), bg `color/fill/neutral/heavy` |
+
+### 2-2. Header (`hasHeader`)
+
+**contentArea** (`1293:122`):
+
+| 속성 | 값 |
+|---|---|
+| Layout | `Column`, 가로 중앙 정렬 |
+| Item gap | `4` |
+| Padding | top `18`, bottom `16`, horizontal `24` |
+| Width | `fillMaxWidth` |
+
+- **Title** (`1293:123`): 항상 표시.
+- **Description** (`1293:124`): `hasDescription = true`일 때만 표시.
+
+**Divider** (`4709:751`): contentArea 하단. full-width 1px, 좌우·상하 indent 없음 (`_indent-col` padding 0). 구현은 v3 `Divider` 컴포넌트 재사용 — 이때 Divider의 Figma property `sideIndent`/`parallelIndent`를 모두 `false`로.
+
+### 2-3. contentWrapper (`5160:10861`)
+
+| 속성 | 값 |
+|---|---|
+| Layout | `Column`, `fillMaxWidth` |
+| Padding | top `12`, horizontal `10` |
+| 내부 | content 슬롯 (`content()`) |
+
+---
+
+## 3. Color 토큰 (v3)
+
+| 요소 | Figma 토큰 | `BezierTheme.colorsV3` 필드 | Light |
+|---|---|---|---|
+| Grabber bar | `color/fill/neutral/heavy` | `fillNeutralHeavy` | `#00000026` |
+| Title | `color/text/neutral` | `textNeutral` | `#000000d9` |
+| Description | `color/text/neutral/lighter` | `textNeutralLighter` | `#00000066` |
+| Divider line | `color/border/neutral` | `borderNeutral` (Divider 컴포넌트가 처리) | `#00000014` |
+
+**스코프 제외 토큰** (Surface/Backdrop = 시트 담당, content 아님): `color/surface`, `color/dim/absolute/black`, `color/elevation/large` (Elevation/Mobile/3).
+
+---
+
+## 4. Typography
+
+| 요소 | Figma 스타일 | `BezierTypo` | size / lineHeight / letterSpacing / weight | 정렬 | overflow |
+|---|---|---|---|---|---|
+| Title | `Typography/heading/small` | `HeadingSmall` | 17 / 24 / -0.1 / Bold | Center | ellipsis + word-break(긴 단어 강제 개행), 2줄에서 잘림 |
+| Description | `Typography/caption/medium` | `CaptionMedium` | 12 / 16 / 0 / Regular | Center | 줄 수 제한 없음 (자유 개행) |
+
+- **Title overflow 출처**: `get_design_context` CSS는 `overflow-hidden` + `text-ellipsis` + `word-break:break-word`만 노출(줄 수 미인코딩). "2줄에서 잘림"은 `get_screenshot`(instance `5105:11844`, header `5620:9964`) 렌더 근거 — Title은 2줄에서 `…`로 잘리고 Description은 전체 노출됨.
+
+- Family: `Inter` (`font-family/sans` / `caption/font-family`).

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -23,6 +23,8 @@ import io.channel.bezier.compose.sample.playground.BadgePlaygroundKey
 import io.channel.bezier.compose.sample.playground.BadgePlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.BottomSheetContentPlaygroundKey
+import io.channel.bezier.compose.sample.playground.BottomSheetContentPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.CardPlaygroundKey
 import io.channel.bezier.compose.sample.playground.CardPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ComponentListKey
@@ -83,6 +85,7 @@ private fun PlaygroundApp() {
                                     onSelectDivider = { backStack.add(DividerPlaygroundKey) },
                                     onSelectToast = { backStack.add(ToastPlaygroundKey) },
                                     onSelectCard = { backStack.add(CardPlaygroundKey) },
+                                    onSelectBottomSheetContent = { backStack.add(BottomSheetContentPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -123,6 +126,9 @@ private fun PlaygroundApp() {
                         }
                         entry<CardPlaygroundKey> {
                             CardPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<BottomSheetContentPlaygroundKey> {
+                            BottomSheetContentPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/BottomSheetContentPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/BottomSheetContentPlaygroundScreen.kt
@@ -1,0 +1,102 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.v3.component.BottomSheetContent
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun BottomSheetContentPlaygroundScreen(onBack: () -> Unit) {
+    var showGrabber by remember { mutableStateOf(true) }
+    var hasTitle by remember { mutableStateOf(true) }
+    var hasDescription by remember { mutableStateOf(true) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("BottomSheetContent") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            BooleanControl(label = "showGrabber", value = showGrabber) { showGrabber = it }
+            BooleanControl(label = "title", value = hasTitle) { hasTitle = it }
+            BooleanControl(label = "description", value = hasDescription) { hasDescription = it }
+
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(24.dp),
+            ) {
+                Box(
+                        modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
+                                .background(BezierTheme.colorsV3.surface),
+                ) {
+                    BottomSheetContent(
+                            title = if (hasTitle) "Title" else null,
+                            description = if (hasDescription) "Description" else null,
+                            showGrabber = showGrabber,
+                    ) {
+                        Box(
+                                modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(96.dp)
+                                        .clip(RoundedCornerShape(12.dp))
+                                        .background(BezierTheme.colorsV3.surfaceLow),
+                        ) {
+                            BezierText(
+                                    text = "content",
+                                    typo = BezierTypo.TextMedium,
+                                    modifier = Modifier.padding(16.dp),
+                                    color = BezierTheme.colorsV3.textNeutral,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -30,6 +30,7 @@ fun ComponentListScreen(
         onSelectDivider: () -> Unit,
         onSelectToast: () -> Unit,
         onSelectCard: () -> Unit,
+        onSelectBottomSheetContent: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -69,6 +70,8 @@ fun ComponentListScreen(
             ComponentRow("Toast", onClick = onSelectToast)
             Divider()
             ComponentRow("Card", onClick = onSelectCard)
+            Divider()
+            ComponentRow("BottomSheetContent", onClick = onSelectBottomSheetContent)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -14,3 +14,4 @@ data object SwitchPlaygroundKey
 data object DividerPlaygroundKey
 data object ToastPlaygroundKey
 data object CardPlaygroundKey
+data object BottomSheetContentPlaygroundKey


### PR DESCRIPTION
## 개요

바텀시트 Surface 내부에 들어가는 **컨텐츠 래퍼** `BottomSheetContent`를 `io.channel.bezier.v3.component`에 구현합니다.

- Linear: [MOB-6415](https://linear.app/channel/issue/MOB-6415/v3-bottomsheetcontent-컴포넌트-구현) (부모: MOB-6369)
- Figma: [🚧 Mobile Components — BottomSheet](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5105-11844&m=dev)

## 스코프

**컨텐츠 래퍼만 담당** — Grabber + Header + content 슬롯.
Backdrop·Surface 컨테이너(배경/모서리/그림자)·드래그·슬라이드 애니메이션은 제외하며, 실제 바텀시트(Holix/Material3 등)가 별도로 래핑합니다 (관련: MOB-6389).

## API

```kotlin
BottomSheetContent(
    modifier: Modifier = Modifier,
    title: String? = null,        // null = 헤더 없음 (hasHeader)
    description: String? = null,  // non-null = 설명 표시 (hasDescription)
    showGrabber: Boolean = false,
    content: @Composable () -> Unit,
)
```

Figma property 매핑: hasHeader→`title`, hasDescription→`description`, showGrabber→`showGrabber`.

## 세부

- **v3 컬러 토큰만 사용**: `fillNeutralHeavy`(grabber) / `textNeutral`(title) / `textNeutralLighter`(description) / `borderNeutral`(divider via v3 `Divider`)
- **타이포**: `HeadingSmall`(title — Center, ellipsis, maxLines 2) / `CaptionMedium`(description — Center, 줄 제한 없음)
- **최적화**: `showGrabber`/`title`/`description` 미지정 시 각 요소 미컴포즈
- sample playground + Nav 등록(NavKeys / ComponentListScreen / MainActivity)
- `docs/components/BottomSheetContent/SPEC.md` — figma-component-spec SSOT (Phase 2 검증 7/7, Phase 3 구현 검증 통과)

## 검증

- `:bezier` + `:sample` Kotlin 컴파일 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)