### PR TITLE
[MOB-6416] v3 TextInput 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/TextInput.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/TextInput.kt
@@ -1,0 +1,312 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.color.BezierSemanticColorV3
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.CancelCircleFilled
+import io.channel.bezier.icon.View
+import io.channel.bezier.icon.ViewOff
+import io.channel.bezier.typography.BezierTypo
+
+private val HorizontalPadding = 10.dp
+private val ItemGap = 6.dp
+private val BorderWidth = 1.5.dp
+private val MinWidth = 40.dp
+private val SystemIconSize = 20.dp
+private const val DisabledAlpha = 0.4f
+
+@Composable
+fun TextInput(
+        value: String,
+        onValueChange: (String) -> Unit,
+        modifier: Modifier = Modifier,
+        variant: TextInputVariant = TextInputVariant.Primary,
+        size: TextInputSize = TextInputSize.Small,
+        enabled: Boolean = true,
+        readOnly: Boolean = false,
+        hasError: Boolean = false,
+        placeholder: String? = null,
+        allowClear: Boolean = false,
+        passwordToggle: Boolean = false,
+        leadingContent: (@Composable () -> Unit)? = null,
+        trailingContent: (@Composable () -> Unit)? = null,
+        keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+        keyboardActions: KeyboardActions = KeyboardActions.Default,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = BezierTheme.colorsV3
+    val focused by interactionSource.collectIsFocusedAsState()
+
+    val fillColor = variant.fillColor(colors, enabled, readOnly, focused, hasError)
+    val borderColor = variant.borderColor(colors, enabled, readOnly, focused, hasError)
+    val valueTextColor = if (readOnly) colors.textNeutralLight else colors.textNeutral
+    val shape = RoundedCornerShape(size.cornerRadius)
+
+    val textStyle = remember(valueTextColor) {
+        TextStyle(
+                color = valueTextColor,
+                fontSize = BezierTypo.TextXLarge.fontSize,
+                lineHeight = BezierTypo.TextXLarge.lineHeight,
+                letterSpacing = BezierTypo.TextXLarge.letterSpacing,
+                fontWeight = FontWeight.Normal,
+        )
+    }
+
+    var passwordVisible by remember { mutableStateOf(false) }
+    val visualTransformation = if (passwordToggle && !passwordVisible) {
+        PasswordVisualTransformation()
+    } else {
+        VisualTransformation.None
+    }
+
+    BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier
+                    .height(size.height)
+                    .widthIn(min = MinWidth)
+                    .graphicsLayer { alpha = if (enabled) 1f else DisabledAlpha }
+                    .clip(shape)
+                    .background(fillColor)
+                    .then(
+                            if (borderColor != null) {
+                                Modifier.border(BorderWidth, borderColor, shape)
+                            } else {
+                                Modifier
+                            },
+                    )
+                    .padding(horizontal = HorizontalPadding, vertical = size.verticalPadding),
+            enabled = enabled,
+            readOnly = readOnly,
+            textStyle = textStyle,
+            singleLine = true,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            visualTransformation = visualTransformation,
+            interactionSource = interactionSource,
+            cursorBrush = SolidColor(valueTextColor),
+            decorationBox = { innerTextField ->
+                Row(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(ItemGap),
+                ) {
+                    if (leadingContent != null) {
+                        leadingContent()
+                    }
+
+                    Box(modifier = Modifier.weight(1f)) {
+                        innerTextField()
+
+                        if (value.isEmpty() && placeholder != null) {
+                            BezierText(
+                                    text = placeholder,
+                                    typo = BezierTypo.TextXLarge,
+                                    color = colors.textNeutralLighter,
+                                    overflow = TextOverflow.Ellipsis,
+                                    maxLines = 1,
+                            )
+                        }
+                    }
+
+                    if (trailingContent != null) {
+                        trailingContent()
+                    }
+
+                    if (allowClear && value.isNotEmpty() && enabled && !readOnly) {
+                        SystemIcon(
+                                icon = BezierIcons.CancelCircleFilled,
+                                onClick = { onValueChange("") },
+                        )
+                    }
+
+                    if (passwordToggle) {
+                        SystemIcon(
+                                icon = if (passwordVisible) BezierIcons.View else BezierIcons.ViewOff,
+                                enabled = enabled,
+                                onClick = { passwordVisible = !passwordVisible },
+                        )
+                    }
+                }
+            },
+    )
+}
+
+@Composable
+private fun SystemIcon(
+        icon: BezierIcon,
+        onClick: () -> Unit,
+        enabled: Boolean = true,
+) {
+    Icon(
+            modifier = Modifier
+                    .size(SystemIconSize)
+                    .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            enabled = enabled,
+                            onClick = onClick,
+                    ),
+            imageVector = icon.imageVector,
+            contentDescription = null,
+            tint = BezierTheme.colorsV3.iconNeutral,
+    )
+}
+
+enum class TextInputVariant {
+    Primary,
+    Secondary,
+    ;
+
+    internal fun fillColor(
+            colors: BezierSemanticColorV3,
+            enabled: Boolean,
+            readOnly: Boolean,
+            focused: Boolean,
+            hasError: Boolean,
+    ): Color = when (this) {
+        Secondary -> colors.fillNeutralLight
+        Primary -> when {
+            !enabled -> colors.fillGrey
+            readOnly -> colors.fillGreyHeavy
+            focused || hasError -> colors.fillGreyLight
+            else -> colors.fillGrey
+        }
+    }
+
+    internal fun borderColor(
+            colors: BezierSemanticColorV3,
+            enabled: Boolean,
+            readOnly: Boolean,
+            focused: Boolean,
+            hasError: Boolean,
+    ): Color? {
+        val primaryBase = if (this == Primary) colors.stateDefault else null
+        return when {
+            !enabled -> primaryBase
+            readOnly -> primaryBase
+            hasError -> colors.stateWarning
+            focused -> colors.fillNeutralHeaviest
+            else -> primaryBase
+        }
+    }
+}
+
+enum class TextInputSize(
+        val height: Dp,
+        val verticalPadding: Dp,
+        val cornerRadius: Dp,
+) {
+    Small(height = 40.dp, verticalPadding = 5.dp, cornerRadius = 12.dp),
+    Medium(height = 48.dp, verticalPadding = 7.dp, cornerRadius = 14.dp),
+}
+
+@Composable
+private fun TextInputMatrix() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            TextInputSize.values().forEach { size ->
+                TextInputVariant.values().forEach { variant ->
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                                text = "$variant · $size",
+                                color = BezierTheme.colorsV3.textNeutral,
+                        )
+                        TextInput(
+                                value = "",
+                                onValueChange = {},
+                                variant = variant,
+                                size = size,
+                                placeholder = "placeholder",
+                                modifier = Modifier.fillMaxWidth(),
+                        )
+                        TextInput(
+                                value = "hong@company.com",
+                                onValueChange = {},
+                                variant = variant,
+                                size = size,
+                                modifier = Modifier.fillMaxWidth(),
+                        )
+                        TextInput(
+                                value = "hong@company.com",
+                                onValueChange = {},
+                                variant = variant,
+                                size = size,
+                                hasError = true,
+                                modifier = Modifier.fillMaxWidth(),
+                        )
+                        TextInput(
+                                value = "hong@company.com",
+                                onValueChange = {},
+                                variant = variant,
+                                size = size,
+                                readOnly = true,
+                                modifier = Modifier.fillMaxWidth(),
+                        )
+                        TextInput(
+                                value = "hong@company.com",
+                                onValueChange = {},
+                                variant = variant,
+                                size = size,
+                                enabled = false,
+                                modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Preview(showBackground = true, widthDp = 360, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun TextInputMatrixPreview() = TextInputMatrix()

--- a/docs/components/TextInput/SPEC.md
+++ b/docs/components/TextInput/SPEC.md
@@ -1,0 +1,243 @@
+# TextInput Spec
+
+> Figma: [🚧 Mobile Components — TextInput](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=3612-2&m=dev)
+> Figma node ID: `3612:2`
+> Design spec doc: [channel-io/team-design — TextInput-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/TextInput-spec.md)
+
+단일 행 텍스트 입력 필드.
+
+- **모양**: 사각형. 모서리 반경 size별 12 / 14.
+- **width**: 기본 fill(부모 폭 채움). 최소 너비 40. (Figma auto-layout 한계로 비율 지정은 FILL/FIXED/HUG로만 표현)
+- **금지 조합**: `secondary` + `error` (Figma description 명시). Figma 매트릭스에는 해당 variant가 존재하나 사용을 금지한다.
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property는 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **variant** | `primary` / `secondary` | 배경·테두리 표현 방식 |
+| **size** | `small` / `medium` | 크기 축 |
+| **state** | `default` / `focused` / `error` / `readOnly` / `disabled` | 시각 상태 축 |
+| **hasValue** | `false` / `true` | placeholder 표시(false) / 입력값 표시(true) |
+
+총 instance: `2 (variant) × 2 (size) × 5 (state) × 2 (hasValue) = 40개` (Figma 노출 인스턴스 수와 일치)
+
+추가 인스턴스 토글 / 슬롯 props (Figma component property 기준):
+
+| Toggle/Slot | 기본값 | 효과 |
+|---|---|---|
+| `hasLeadingContent` | `false` | true 면 leading 위치에 슬롯 표시 (아이콘 또는 TextInputAffix 배치) |
+| `hasTrailingContent` | `false` | true 면 trailing 위치에 20 슬롯 표시 |
+| `allowClear` | `false` | 시스템 자동 요소. 입력값 삭제(X) 버튼 |
+| `passwordToggle` | `false` | 시스템 자동 요소. 비밀번호 표시/숨김(눈) 버튼 |
+| `placeholder` | `"placeholder"` | 미입력 시 표시 텍스트 |
+| `leadingContent` / `trailingContent` | (없음) | 슬롯 콘텐츠 |
+
+---
+
+## 2. Size 별 Spec
+
+단위는 Android 관용에 따라 `dp` (텍스트는 `sp`로 해석).
+
+| Size | Height | Horizontal Padding | Vertical Padding | Item Gap | Corner Radius | Min Height | Min Width |
+|---|---|---|---|---|---|---|---|
+| `small` | 40 | 10 | 5 | 6 | 12 | 20 | 40 |
+| `medium` | 48 | 10 | 7 | 6 | 14 | 20 | 40 |
+
+### 슬롯 크기
+
+| 슬롯 | small | medium |
+|---|---|---|
+| `leadingContent` | 26 × 20 | 30 × 24 |
+| `trailingContent` | 20 × 20 | 20 × 20 |
+| `allowClear` (시스템) | 20 × 20 | 20 × 20 |
+| `passwordToggle` (시스템) | 20 × 20 | 20 × 20 |
+
+- Corner radius는 Variable `radius/12`(small) / `radius/14`(medium).
+- `leadingContent` / `trailingContent`는 콘텐츠 슬롯 — 위 수치는 Figma placeholder 콘텐츠 기준 크기이며, 실제 콘텐츠는 슬롯에 세로 중앙 정렬한다.
+- `allowClear` / `passwordToggle`는 20 아이콘 슬롯이다. 내부 shape inset은 §7 참조 (allowClear `8.33%`, passwordToggle 비대칭).
+
+---
+
+## 3. Variant × State 별 컬러 토큰
+
+### Background (fill)
+
+| variant | state | Variable | Raw |
+|---|---|---|---|
+| `primary` | `default` | `color/fill/grey` | `#fbfbfb` |
+| `primary` | `focused` | `color/fill/grey/light` | `#fdfdfd` |
+| `primary` | `error` | `color/fill/grey/light` | `#fdfdfd` |
+| `primary` | `readOnly` | `color/fill/grey/heavy` | `#f7f7f8` |
+| `primary` | `disabled` | `color/fill/grey` | `#fbfbfb` |
+| `secondary` | `default` | `color/fill/neutral/light` | `#0000000d` |
+| `secondary` | `focused` | `color/fill/neutral/light` | `#0000000d` |
+| `secondary` | `error` | `color/fill/neutral/light` | `#0000000d` |
+| `secondary` | `readOnly` | `color/fill/neutral/light` | `#0000000d` |
+| `secondary` | `disabled` | `color/fill/neutral/light` | `#0000000d` |
+
+> `secondary`의 fill은 모든 state에서 `color/fill/neutral/light`로 동일하다.
+
+### Border (inner shadow, inset 1.5 spread)
+
+| variant | state | Variable | Raw |
+|---|---|---|---|
+| `primary` | `default` | `color/state/default` | `#00000026` |
+| `primary` | `focused` | `color/state/active` | `#000000d9` |
+| `primary` | `error` | `color/state/warning` | `#e67f2b` |
+| `primary` | `readOnly` | `color/state/default` | `#00000026` |
+| `primary` | `disabled` | `color/state/default` | `#00000026` |
+| `secondary` | `default` | — *(border 없음)* | — |
+| `secondary` | `focused` | `color/state/active` | `#000000d9` |
+| `secondary` | `error` | `color/state/warning` | `#e67f2b` |
+| `secondary` | `readOnly` | — *(border 없음)* | — |
+| `secondary` | `disabled` | — *(border 없음)* | — |
+
+> Border effect: `INNER_SHADOW`, offset `(0,0)`, radius `0`, spread `1.5` → inset 1.5 테두리.
+> `secondary`는 `focused` / `error`에서만 border를 가진다 (default / readOnly / disabled는 border 없음).
+
+### Text color
+
+| hasValue | state | Variable | Raw |
+|---|---|---|---|
+| `false` (placeholder) | 모든 state | `color/text/neutral/lighter` | `#00000066` |
+| `true` (value) | `default` / `focused` / `error` / `disabled` | `color/text/neutral` | `#000000d9` |
+| `true` (value) | `readOnly` | `color/text/neutral/light` | `#00000099` |
+
+> placeholder 텍스트 색은 모든 state에서 `color/text/neutral/lighter`로 동일하다.
+> value 텍스트는 `readOnly`에서만 한 단계 옅은 `color/text/neutral/light`를 쓴다.
+
+### Icon color (시스템 요소 `allowClear` / `passwordToggle`)
+
+`allowClear` / `passwordToggle` 아이콘은 Figma에서 raw SVG(fill `black`, opacity `0.4`)로 인라인되어 있어 변수(`variable_defs`)에 노출되지 않는다. 렌더 색은 `black @ 0.4` = `#00000066`.
+
+| 슬롯 | Raw | 비고 |
+|---|---|---|
+| `allowClear` / `passwordToggle` | `#00000066` (black @ 0.4) | 시스템 아이콘. `leadingContent`/`trailingContent`는 caller 콘텐츠라 색 미지정 |
+
+---
+
+## 4. Disabled
+
+| Property | 값 |
+|---|---|
+| opacity | Variable `opacity/disabled` = `40` (0.4) |
+
+`disabled` state는 해당 variant의 `default` 시각(fill·border)에 컨테이너 전체 opacity `0.4`를 적용한다 (별도 색 토큰 변경 없음).
+
+---
+
+## 5. State 별 시각 동작
+
+| State | primary | secondary | 인터랙션 |
+|---|---|---|---|
+| `default` | fill `grey` + border `default` | fill `neutral/light` (border 없음) | 편집 가능 |
+| `focused` | fill `grey/light` + border `active` | fill `neutral/light` + border `active` | 키보드 포커스 시. 런타임 파생 |
+| `error` | fill `grey/light` + border `warning` | fill `neutral/light` + border `warning` (사용 금지) | 편집 가능 |
+| `readOnly` | fill `grey/heavy` + border `default` | fill `neutral/light` (border 없음) | 편집 불가·선택 가능 |
+| `disabled` | `default` 시각 + opacity 0.4 | `default` 시각 + opacity 0.4 | 비활성 |
+
+### State 별 구현 가이드
+
+- `focused`는 caller가 주입하는 값이 아니라 키보드 포커스에서 런타임 파생한다.
+- `error` / `readOnly` / `disabled`는 caller 주입 값이다.
+- `disabled`는 `default` 시각 위에 opacity 0.4만 적용한다 (readOnly / error / focused 시각과 결합하지 않음).
+- `readOnly`는 배타적 시각 상태다 (active / warning border를 표시하지 않음).
+
+---
+
+## 6. Typography
+
+이 컴포넌트의 텍스트 노드(placeholder / value)를 두 케이스로 분리해 기재한다.
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 | 구성 |
+|---|---|---|---|
+| placeholder / value | `Typography/text/xlarge` | `Typography/text/xlarge` | family=`text/font-family`(Inter) · weight=`text/weight/regular`(400) · size=`text/size/xlarge`(16) · line-height=`text/line-height/xlarge`(24) · letter-spacing=`text/letter-spacing/tight`(-0.1) |
+
+### Case B — Custom Typography (토큰 미적용)
+
+없음. 모든 텍스트가 `Typography/text/xlarge` 토큰을 사용한다.
+
+---
+
+## 7. 아이콘 자산 (시스템 요소)
+
+| 항목 | allowClear | passwordToggle |
+|---|---|---|
+| Figma asset | raw SVG (`944dd209…svg`) | raw SVG (`fda3ae70…svg`) |
+| 형태 | 채워진 원 + X (cancel-circle-filled) | 눈 (view) |
+| 슬롯 크기 | 20 × 20 | 20 × 20 |
+| 내부 shape inset | `8.33%` | `top 25% / bottom 26.62% / left 10.33% / right 8.49%` |
+| 색상 | black @ 0.4 (`#00000066`) | black @ 0.4 (`#00000066`) |
+
+> `allowClear`는 입력값이 있을 때 노출되어 값을 삭제한다. `passwordToggle`은 비밀번호 표시/숨김을 토글한다.
+
+---
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| Compose 구현 | `bezier/src/main/java/io/channel/bezier/v3/component/TextInput.kt` (`@Composable fun TextInput(...)`) |
+| variant / size 정의 | 같은 파일 안 `enum class TextInputVariant`, `enum class TextInputSize` |
+| 컬러 토큰 | `BezierTheme.colorsV3.<token>` (`BezierSemanticColorV3` 멤버) |
+| Typography | `io.channel.bezier.typography.BezierTypo.TextXLarge` |
+| allowClear 아이콘 | `BezierIcons.CancelCircleFilled` |
+| passwordToggle 아이콘 | `BezierIcons.View` / `BezierIcons.ViewOff` |
+
+### 컬러 토큰 → V3 매핑 (`BezierSemanticColorV3`)
+
+| Figma Variable | Raw | V3 프로퍼티 | Light 매핑 |
+|---|---|---|---|
+| `color/fill/grey` | `#fbfbfb` | `fillGrey` | `Grey50` |
+| `color/fill/grey/light` | `#fdfdfd` | `fillGreyLight` | `Grey25` |
+| `color/fill/grey/heavy` | `#f7f7f8` | `fillGreyHeavy` | `Grey100` |
+| `color/fill/neutral/light` | `#0000000d` | `fillNeutralLight` | `Black5` |
+| `color/text/neutral` | `#000000d9` | `textNeutral` | `Black85` |
+| `color/text/neutral/light` | `#00000099` | `textNeutralLight` | `Black60` |
+| `color/text/neutral/lighter` | `#00000066` | `textNeutralLighter` | `Black40` |
+| `color/state/default` | `#00000026` | `stateDefault` | `Black15` |
+| `color/state/active` | `#000000d9` | `fillNeutralHeaviest` | `Black85` |
+| `color/state/warning` | `#e67f2b` | `stateWarning` | `Orange400` |
+| 시스템 아이콘 (black @ 0.4) | `#00000066` | `iconNeutral` | `Black40` |
+
+> `color/state/active`(#000000d9 = Black85)에 정확히 대응하는 `stateActive` 프로퍼티가 V3에 없다. 동일 raw 값(Black85)을 갖고, Switch의 active(on) 트랙이 사용하는 `fillNeutralHeaviest`로 매핑한다.
+
+---
+
+## 9. Variant 매트릭스
+
+총 instance: `2 (variant) × 2 (size) × 5 (state) × 2 (hasValue) = 40개`
+
+```
+variant × size × state × hasValue = Node ID
+
+primary  small  default  false → 1105:3     true → 2451:146
+primary  small  focused  false → 1105:5     true → 2451:154
+primary  small  error    false → 1105:7     true → 2451:162
+primary  small  readOnly false → 4548:925   true → 4548:931
+primary  small  disabled false → 1105:9     true → 2451:170
+
+primary  medium default  false → 1105:11    true → 2451:178
+primary  medium focused  false → 1105:13    true → 2451:186
+primary  medium error    false → 1105:15    true → 2451:194
+primary  medium readOnly false → 4548:937   true → 4548:943
+primary  medium disabled false → 1105:17    true → 2451:202
+
+secondary small  default  false → 1105:27   true → 2451:242
+secondary small  focused  false → 1105:29   true → 2451:250
+secondary small  error    false → 1105:31   true → 2451:258
+secondary small  readOnly false → 4548:949  true → 4548:955
+secondary small  disabled false → 1105:33   true → 2451:266
+
+secondary medium default  false → 1105:35   true → 2451:274
+secondary medium focused  false → 1105:37   true → 2451:282
+secondary medium error    false → 1105:39   true → 2451:290
+secondary medium readOnly false → 4548:961  true → 4548:967
+secondary medium disabled false → 1105:41   true → 2451:298
+```

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -25,6 +25,8 @@ import io.channel.bezier.compose.sample.playground.ButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.CardPlaygroundKey
 import io.channel.bezier.compose.sample.playground.CardPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.TextInputPlaygroundKey
+import io.channel.bezier.compose.sample.playground.TextInputPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ComponentListKey
 import io.channel.bezier.compose.sample.playground.ComponentListScreen
 import io.channel.bezier.compose.sample.playground.DividerPlaygroundKey
@@ -83,6 +85,7 @@ private fun PlaygroundApp() {
                                     onSelectDivider = { backStack.add(DividerPlaygroundKey) },
                                     onSelectToast = { backStack.add(ToastPlaygroundKey) },
                                     onSelectCard = { backStack.add(CardPlaygroundKey) },
+                                    onSelectTextInput = { backStack.add(TextInputPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -123,6 +126,9 @@ private fun PlaygroundApp() {
                         }
                         entry<CardPlaygroundKey> {
                             CardPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<TextInputPlaygroundKey> {
+                            TextInputPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -30,6 +30,7 @@ fun ComponentListScreen(
         onSelectDivider: () -> Unit,
         onSelectToast: () -> Unit,
         onSelectCard: () -> Unit,
+        onSelectTextInput: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -69,6 +70,8 @@ fun ComponentListScreen(
             ComponentRow("Toast", onClick = onSelectToast)
             Divider()
             ComponentRow("Card", onClick = onSelectCard)
+            Divider()
+            ComponentRow("TextInput", onClick = onSelectTextInput)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -14,3 +14,4 @@ data object SwitchPlaygroundKey
 data object DividerPlaygroundKey
 data object ToastPlaygroundKey
 data object CardPlaygroundKey
+data object TextInputPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/TextInputPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/TextInputPlaygroundScreen.kt
@@ -1,0 +1,97 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.TextInput
+import io.channel.bezier.v3.component.TextInputSize
+import io.channel.bezier.v3.component.TextInputVariant
+
+@Composable
+fun TextInputPlaygroundScreen(onBack: () -> Unit) {
+    var value by remember { mutableStateOf("") }
+    var variant by remember { mutableStateOf(TextInputVariant.Primary) }
+    var size by remember { mutableStateOf(TextInputSize.Small) }
+    var enabled by remember { mutableStateOf(true) }
+    var readOnly by remember { mutableStateOf(false) }
+    var hasError by remember { mutableStateOf(false) }
+    var allowClear by remember { mutableStateOf(false) }
+    var passwordToggle by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("TextInput") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+            ) {
+                TextInput(
+                        value = value,
+                        onValueChange = { value = it },
+                        variant = variant,
+                        size = size,
+                        enabled = enabled,
+                        readOnly = readOnly,
+                        hasError = hasError,
+                        placeholder = "placeholder",
+                        allowClear = allowClear,
+                        passwordToggle = passwordToggle,
+                        modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            Divider()
+
+            EnumControl("variant", TextInputVariant.values(), variant) { variant = it }
+            EnumControl("size", TextInputSize.values(), size) { size = it }
+            BooleanControl("enabled", enabled) { enabled = it }
+            BooleanControl("readOnly", readOnly) { readOnly = it }
+            BooleanControl("hasError", hasError) { hasError = it }
+            BooleanControl("allowClear", allowClear) { allowClear = it }
+            BooleanControl("passwordToggle", passwordToggle) { passwordToggle = it }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

Figma TextInput(v3, node `3612:2`)을 `io.channel.bezier.v3.component` 패키지에 구현합니다.

- Linear: [MOB-6416](https://linear.app/channel/issue/MOB-6416/v3-textinput-컴포넌트-구현) (부모 MOB-6369)
- Figma: [TextInput](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=3612-2&m=dev)

## 범위

- `TextInput.kt` 신규 — `TextInputVariant`(Primary/Secondary) · `TextInputSize`(Small/Medium) enum 동거
- variant 2 × size 2 × state 5(default/focused/error/readOnly/disabled) × hasValue 2 = 40 매트릭스
- 슬롯: `leadingContent` / `trailingContent` (`(@Composable () -> Unit)?`)
- 시스템 요소: `allowClear`(`BezierIcons.CancelCircleFilled`) / `passwordToggle`(`BezierIcons.View`/`ViewOff`)
- v3 컬러 토큰(`BezierTheme.colorsV3`) 전용, 타이포 `BezierTypo.TextXLarge`
- Layout: Small h40/pad5/r12, Medium h48/pad7/r14 · hPad10 · gap6 · minW40
- 플레이그라운드 등록(`TextInputPlaygroundScreen` + NavKeys·ComponentListScreen·MainActivity)

## 설계 결정

- `state` 축은 enum이 아닌 `enabled`/`readOnly`/`hasError` 분해 + `focused` 런타임 파생(`collectIsFocusedAsState`) — v3 Switch·구 TextField 컨벤션
- `color/state/active`(#000000d9)는 V3에 대응 토큰이 없어 동일 raw(Black85)·Switch active 트랙과 동일한 `fillNeutralHeaviest`로 매핑
- secondary+error는 Figma에 실재하나 description상 사용 금지 조합

## 검증

- SSOT spec: `docs/components/TextInput/SPEC.md`
- figma-component-spec Phase 2(spec 검증 7종) · Phase 3(구현 검증) 통과
- `:sample:assembleDebug` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)