### PR TITLE
[MOB-6443] v3 Section 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Section.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Section.kt
@@ -1,0 +1,141 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+@Composable
+fun Section(
+        modifier: Modifier = Modifier,
+        label: String? = null,
+        variant: SectionVariant = SectionVariant.Solid,
+        content: @Composable () -> Unit,
+) {
+    Column(
+            modifier = modifier.fillMaxWidth(),
+    ) {
+        if (label != null) {
+            SectionLabel(label = label)
+        }
+
+        when (variant) {
+            SectionVariant.Solid -> Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    content = { content() },
+            )
+
+            SectionVariant.Card -> Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    content = content,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(
+        label: String,
+        modifier: Modifier = Modifier,
+) {
+    Row(
+            modifier = modifier
+                    .fillMaxWidth()
+                    .heightIn(min = SectionLabelMinHeight)
+                    .padding(horizontal = SectionLabelHorizontalPadding),
+            verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BezierText(
+                text = label,
+                typo = BezierTypo.TextMedium,
+                weight = BezierWeight.Bold,
+                color = BezierTheme.colorsV3.textNeutral,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+        )
+    }
+}
+
+enum class SectionVariant {
+    Solid,
+    Card,
+}
+
+private val SectionLabelMinHeight: Dp = 32.dp
+private val SectionLabelHorizontalPadding: Dp = 10.dp
+
+@Composable
+private fun SectionPreviewContent() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .fillMaxSize()
+                        .padding(24.dp),
+        ) {
+            Section(label = "Section Label") {
+                repeat(3) {
+                    BaseItem(
+                            label = "Label",
+                            size = BaseItemSize.Small,
+                            leadingContent = { SectionPreviewLeadingIcon(BezierIcons.Plus) },
+                    )
+                }
+            }
+
+            Section(
+                    modifier = Modifier.padding(top = 24.dp),
+                    label = "Section Label",
+                    variant = SectionVariant.Card,
+            ) {
+                repeat(4) { index ->
+                    if (index > 0) {
+                        Divider(sideIndent = false, parallelIndent = false)
+                    }
+                    BaseItem(
+                            label = "Label",
+                            size = BaseItemSize.Medium,
+                            leadingContent = { SectionPreviewLeadingIcon(BezierIcons.Plus) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionPreviewLeadingIcon(icon: BezierIcon) {
+    Icon(
+            modifier = Modifier.fillMaxSize(),
+            imageVector = icon.imageVector,
+            tint = BezierTheme.colorsV3.iconNeutralHeavier,
+            contentDescription = null,
+    )
+}
+
+@Preview(showBackground = true, widthDp = 400)
+@Composable
+private fun SectionPreview() = SectionPreviewContent()
+
+@Preview(showBackground = true, widthDp = 400, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun SectionDarkPreview() = SectionPreviewContent()

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Section.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Section.kt
@@ -2,16 +2,21 @@ package io.channel.bezier.v3.component
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -20,6 +25,8 @@ import io.channel.bezier.BezierIcon
 import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.ChevronSmallRight
+import io.channel.bezier.icon.Folder
 import io.channel.bezier.icon.Plus
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
@@ -28,6 +35,9 @@ import io.channel.bezier.typography.BezierWeight
 fun Section(
         modifier: Modifier = Modifier,
         label: String? = null,
+        labelColor: SectionLabelColor = SectionLabelColor.NeutralDark,
+        labelLeadingContent: (@Composable () -> Unit)? = null,
+        labelTrailingContent: (@Composable () -> Unit)? = null,
         variant: SectionVariant = SectionVariant.Solid,
         content: @Composable () -> Unit,
 ) {
@@ -35,7 +45,12 @@ fun Section(
             modifier = modifier.fillMaxWidth(),
     ) {
         if (label != null) {
-            SectionLabel(label = label)
+            SectionLabel(
+                    label = label,
+                    color = labelColor,
+                    leadingContent = labelLeadingContent,
+                    trailingContent = labelTrailingContent,
+            )
         }
 
         when (variant) {
@@ -55,6 +70,9 @@ fun Section(
 @Composable
 private fun SectionLabel(
         label: String,
+        color: SectionLabelColor,
+        leadingContent: (@Composable () -> Unit)?,
+        trailingContent: (@Composable () -> Unit)?,
         modifier: Modifier = Modifier,
 ) {
     Row(
@@ -62,16 +80,39 @@ private fun SectionLabel(
                     .fillMaxWidth()
                     .heightIn(min = SectionLabelMinHeight)
                     .padding(horizontal = SectionLabelHorizontalPadding),
+            horizontalArrangement = Arrangement.spacedBy(SectionLabelTrailingGap),
             verticalAlignment = Alignment.CenterVertically,
     ) {
-        BezierText(
-                text = label,
-                typo = BezierTypo.TextMedium,
-                weight = BezierWeight.Bold,
-                color = BezierTheme.colorsV3.textNeutral,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-        )
+        Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(SectionLabelLeadingGap),
+                verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (leadingContent != null) {
+                Box(modifier = Modifier.size(SectionLabelSlotSize)) {
+                    leadingContent()
+                }
+            }
+
+            BezierText(
+                    text = label,
+                    typo = BezierTypo.TextMedium,
+                    weight = BezierWeight.Bold,
+                    color = color.textColor(),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    modifier = Modifier.weight(1f),
+            )
+        }
+
+        if (trailingContent != null) {
+            Box(
+                    modifier = Modifier.height(SectionLabelSlotSize),
+                    contentAlignment = Alignment.Center,
+            ) {
+                trailingContent()
+            }
+        }
     }
 }
 
@@ -80,8 +121,22 @@ enum class SectionVariant {
     Card,
 }
 
+enum class SectionLabelColor {
+    NeutralDark,
+    NeutralLight,
+}
+
+@Composable
+private fun SectionLabelColor.textColor(): Color = when (this) {
+    SectionLabelColor.NeutralDark -> BezierTheme.colorsV3.textNeutral
+    SectionLabelColor.NeutralLight -> BezierTheme.colorsV3.textNeutralLighter
+}
+
 private val SectionLabelMinHeight: Dp = 32.dp
 private val SectionLabelHorizontalPadding: Dp = 10.dp
+private val SectionLabelLeadingGap: Dp = 8.dp
+private val SectionLabelTrailingGap: Dp = 4.dp
+private val SectionLabelSlotSize: Dp = 20.dp
 
 @Composable
 private fun SectionPreviewContent() {
@@ -91,20 +146,25 @@ private fun SectionPreviewContent() {
                         .background(BezierTheme.colorsV3.surfaceLow)
                         .fillMaxSize()
                         .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
-            Section(label = "Section Label") {
+            Section(
+                    label = "Section Label",
+                    labelLeadingContent = { SectionPreviewIcon(BezierIcons.Folder) },
+                    labelTrailingContent = { SectionPreviewIcon(BezierIcons.ChevronSmallRight) },
+            ) {
                 repeat(3) {
                     BaseItem(
                             label = "Label",
                             size = BaseItemSize.Small,
-                            leadingContent = { SectionPreviewLeadingIcon(BezierIcons.Plus) },
+                            leadingContent = { SectionPreviewIcon(BezierIcons.Plus) },
                     )
                 }
             }
 
             Section(
-                    modifier = Modifier.padding(top = 24.dp),
-                    label = "Section Label",
+                    label = "Overlay Label",
+                    labelColor = SectionLabelColor.NeutralLight,
                     variant = SectionVariant.Card,
             ) {
                 repeat(4) { index ->
@@ -114,7 +174,7 @@ private fun SectionPreviewContent() {
                     BaseItem(
                             label = "Label",
                             size = BaseItemSize.Medium,
-                            leadingContent = { SectionPreviewLeadingIcon(BezierIcons.Plus) },
+                            leadingContent = { SectionPreviewIcon(BezierIcons.Plus) },
                     )
                 }
             }
@@ -123,7 +183,7 @@ private fun SectionPreviewContent() {
 }
 
 @Composable
-private fun SectionPreviewLeadingIcon(icon: BezierIcon) {
+private fun SectionPreviewIcon(icon: BezierIcon) {
     Icon(
             modifier = Modifier.fillMaxSize(),
             imageVector = icon.imageVector,

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -35,6 +35,8 @@ import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.SectionPlaygroundKey
+import io.channel.bezier.compose.sample.playground.SectionPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.StatusPlaygroundKey
@@ -85,6 +87,7 @@ private fun PlaygroundApp() {
                                     onSelectDivider = { backStack.add(DividerPlaygroundKey) },
                                     onSelectToast = { backStack.add(ToastPlaygroundKey) },
                                     onSelectCard = { backStack.add(CardPlaygroundKey) },
+                                    onSelectSection = { backStack.add(SectionPlaygroundKey) },
                                     onSelectTextInput = { backStack.add(TextInputPlaygroundKey) },
                             )
                         }
@@ -126,6 +129,9 @@ private fun PlaygroundApp() {
                         }
                         entry<CardPlaygroundKey> {
                             CardPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<SectionPlaygroundKey> {
+                            SectionPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                         entry<TextInputPlaygroundKey> {
                             TextInputPlaygroundScreen(onBack = { backStack.removeLastOrNull() })

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -30,6 +30,7 @@ fun ComponentListScreen(
         onSelectDivider: () -> Unit,
         onSelectToast: () -> Unit,
         onSelectCard: () -> Unit,
+        onSelectSection: () -> Unit,
         onSelectTextInput: () -> Unit,
 ) {
     Scaffold(
@@ -70,6 +71,8 @@ fun ComponentListScreen(
             ComponentRow("Toast", onClick = onSelectToast)
             Divider()
             ComponentRow("Card", onClick = onSelectCard)
+            Divider()
+            ComponentRow("Section", onClick = onSelectSection)
             Divider()
             ComponentRow("TextInput", onClick = onSelectTextInput)
             Divider()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -14,4 +14,5 @@ data object SwitchPlaygroundKey
 data object DividerPlaygroundKey
 data object ToastPlaygroundKey
 data object CardPlaygroundKey
+data object SectionPlaygroundKey
 data object TextInputPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/SectionPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/SectionPlaygroundScreen.kt
@@ -1,0 +1,103 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.icon.Bookmark
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.icon.Star
+import io.channel.bezier.v3.component.BaseItem
+import io.channel.bezier.v3.component.BaseItemSize
+import io.channel.bezier.v3.component.Divider
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.Section
+import io.channel.bezier.v3.component.SectionVariant
+
+@Composable
+fun SectionPlaygroundScreen(onBack: () -> Unit) {
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Section") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .verticalScroll(rememberScrollState())
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
+            Section(label = "Solid") {
+                PlaygroundSectionItem(BezierIcons.Plus, "Add item")
+                PlaygroundSectionItem(BezierIcons.Star, "Favorites")
+                PlaygroundSectionItem(BezierIcons.Bookmark, "Bookmarks")
+            }
+
+            Section(
+                    label = "Card",
+                    variant = SectionVariant.Card,
+            ) {
+                PlaygroundSectionItem(BezierIcons.Plus, "Add item")
+                Divider(sideIndent = false, parallelIndent = false)
+                PlaygroundSectionItem(BezierIcons.Star, "Favorites")
+                Divider(sideIndent = false, parallelIndent = false)
+                PlaygroundSectionItem(BezierIcons.Bookmark, "Bookmarks")
+            }
+
+            Section(variant = SectionVariant.Card) {
+                PlaygroundSectionItem(BezierIcons.Plus, "Section without label")
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaygroundSectionItem(
+        icon: BezierIcon,
+        label: String,
+) {
+    BaseItem(
+            modifier = Modifier.fillMaxWidth(),
+            label = label,
+            size = BaseItemSize.Medium,
+            leadingContent = {
+                Icon(
+                        modifier = Modifier.fillMaxSize(),
+                        imageVector = icon.imageVector,
+                        tint = BezierTheme.colorsV3.iconNeutralHeavier,
+                        contentDescription = null,
+                )
+            },
+    )
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/SectionPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/SectionPlaygroundScreen.kt
@@ -2,10 +2,12 @@ package io.channel.bezier.compose.sample.playground
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
@@ -20,6 +22,8 @@ import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.icon.ArrowLeft
 import io.channel.bezier.icon.Bookmark
+import io.channel.bezier.icon.ChevronSmallRight
+import io.channel.bezier.icon.Folder
 import io.channel.bezier.icon.Plus
 import io.channel.bezier.icon.Star
 import io.channel.bezier.v3.component.BaseItem
@@ -29,6 +33,7 @@ import io.channel.bezier.v3.component.IconButton
 import io.channel.bezier.v3.component.IconButtonSize
 import io.channel.bezier.v3.component.IconButtonVariant
 import io.channel.bezier.v3.component.Section
+import io.channel.bezier.v3.component.SectionLabelColor
 import io.channel.bezier.v3.component.SectionVariant
 
 @Composable
@@ -65,6 +70,15 @@ fun SectionPlaygroundScreen(onBack: () -> Unit) {
             }
 
             Section(
+                    label = "Label with leading & trailing",
+                    labelLeadingContent = { PlaygroundLabelIcon(BezierIcons.Folder) },
+                    labelTrailingContent = { PlaygroundLabelIcon(BezierIcons.ChevronSmallRight) },
+            ) {
+                PlaygroundSectionItem(BezierIcons.Plus, "Add item")
+                PlaygroundSectionItem(BezierIcons.Star, "Favorites")
+            }
+
+            Section(
                     label = "Card",
                     variant = SectionVariant.Card,
             ) {
@@ -73,6 +87,16 @@ fun SectionPlaygroundScreen(onBack: () -> Unit) {
                 PlaygroundSectionItem(BezierIcons.Star, "Favorites")
                 Divider(sideIndent = false, parallelIndent = false)
                 PlaygroundSectionItem(BezierIcons.Bookmark, "Bookmarks")
+            }
+
+            Section(
+                    label = "Neutral light (overlay)",
+                    labelColor = SectionLabelColor.NeutralLight,
+                    variant = SectionVariant.Card,
+            ) {
+                PlaygroundSectionItem(BezierIcons.Plus, "Add item")
+                Divider(sideIndent = false, parallelIndent = false)
+                PlaygroundSectionItem(BezierIcons.Star, "Favorites")
             }
 
             Section(variant = SectionVariant.Card) {
@@ -100,4 +124,16 @@ private fun PlaygroundSectionItem(
                 )
             },
     )
+}
+
+@Composable
+private fun PlaygroundLabelIcon(icon: BezierIcon) {
+    Box(modifier = Modifier.size(20.dp)) {
+        Icon(
+                modifier = Modifier.fillMaxSize(),
+                imageVector = icon.imageVector,
+                tint = BezierTheme.colorsV3.iconNeutralHeavier,
+                contentDescription = null,
+        )
+    }
 }


### PR DESCRIPTION
## 개요
Figma Section 컴포넌트([node 4990:10604](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4990-10604&m=dev))와 SectionLabel([node 1856:32](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1856-32&m=dev))을 v3 패키지에 구현합니다.

## 변경 사항
### Section
- `io.channel.bezier.v3.component.Section` — SectionLabel 헤더(optional) + content 슬롯 컨테이너
- `SectionVariant { Solid, Card }` — `solid`는 배경 없는 리스트, `card`는 기존 `Card` 컴포넌트로 감쌈

### SectionLabel (Section 헤더, 내부 전용)
- `label` 텍스트: `BezierTypo.TextMedium` + Bold
- `SectionLabelColor { NeutralDark, NeutralLight }` — neutral-dark=`textNeutral` / neutral-light(overlay용)=`textNeutralLighter`
- `labelLeadingContent` / `labelTrailingContent` — 20dp 아이콘/액션 슬롯 (leading↔text gap 8, ↔trailing gap 4)
- 컨테이너: min-height 32dp, horizontal padding 10dp

### 공통
- 기존 컴포넌트 재사용(최적화): `Card`(카드 래퍼) · `BaseItem`(SectionItem) · `Divider`(item 구분)
- v3 컬러 토큰만 사용: `textNeutral` / `textNeutralLighter` / `surface` / `borderNeutral`
- 샘플 앱 Section 플레이그라운드 추가 (solid / leading+trailing / card / neutral-light overlay / label 없음)

## 검증
- `figma-component-spec` 사이클 완료: SPEC 작성 → 검증 7종(Properties / Layout / Color / Typography / Asset / Noise / 코드심볼) 통과 → Compose 구현 검증 통과
- SectionLabel 확장 후 Properties / Layout / Color / 구현 재검증 통과
- `:bezier` / `:sample` compile 성공, light/dark `@Preview` 포함

## 티켓
[MOB-6443](https://linear.app/channel/issue/MOB-6443) (부모: MOB-6369)

🤖 Generated with [Claude Code](https://claude.com/claude-code)