### PR TITLE
[MOB-6549] v3 Modal / ConfirmModal 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/ConfirmModal.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/ConfirmModal.kt
@@ -1,0 +1,254 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+enum class ConfirmModalButtonLayout {
+    Horizontal,
+    Vertical,
+}
+
+@Composable
+fun ConfirmModal(
+        title: String,
+        confirmText: String,
+        onConfirmClick: () -> Unit,
+        cancelText: String,
+        onCancelClick: () -> Unit,
+        onDismissRequest: () -> Unit,
+        modifier: Modifier = Modifier,
+        description: String? = null,
+        altActionText: String? = null,
+        onAltActionClick: () -> Unit = {},
+        destructive: Boolean = false,
+        buttonLayout: ConfirmModalButtonLayout = ConfirmModalButtonLayout.Horizontal,
+        cancellable: Boolean = true,
+        customContent: (@Composable () -> Unit)? = null,
+) {
+    Modal(
+            onDismissRequest = onDismissRequest,
+            modifier = modifier,
+            cancellable = cancellable,
+    ) {
+        ConfirmModalContent(
+                title = title,
+                description = description,
+        )
+
+        if (customContent != null) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                customContent()
+            }
+        }
+
+        ConfirmModalButtons(
+                confirmText = confirmText,
+                onConfirmClick = onConfirmClick,
+                cancelText = cancelText,
+                onCancelClick = onCancelClick,
+                altActionText = altActionText,
+                onAltActionClick = onAltActionClick,
+                destructive = destructive,
+                buttonLayout = buttonLayout,
+        )
+    }
+}
+
+@Composable
+private fun ConfirmModalContent(
+        title: String,
+        description: String?,
+) {
+    val textColor = BezierTheme.colorsV3.textNeutral
+
+    Column(
+            modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = ConfirmModalContentBottomPadding),
+            verticalArrangement = Arrangement.spacedBy(ConfirmModalContentGap),
+    ) {
+        BezierText(
+                modifier = Modifier.fillMaxWidth(),
+                text = title,
+                typo = BezierTypo.HeadingXSmall,
+                color = textColor,
+                textAlign = TextAlign.Center,
+        )
+
+        if (description != null) {
+            BezierText(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = description,
+                    typo = BezierTypo.TextLarge,
+                    weight = BezierWeight.Regular,
+                    color = textColor,
+                    textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfirmModalButtons(
+        confirmText: String,
+        onConfirmClick: () -> Unit,
+        cancelText: String,
+        onCancelClick: () -> Unit,
+        altActionText: String?,
+        onAltActionClick: () -> Unit,
+        destructive: Boolean,
+        buttonLayout: ConfirmModalButtonLayout,
+) {
+    val confirmSemantic = if (destructive) ButtonSemantic.Destructive else ButtonSemantic.Primary
+    val isVertical = buttonLayout == ConfirmModalButtonLayout.Vertical
+
+    if (isVertical) {
+        Column(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = ConfirmModalButtonsTopPadding),
+                verticalArrangement = Arrangement.spacedBy(ConfirmModalVerticalButtonGap),
+        ) {
+            Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = confirmText,
+                    onClick = onConfirmClick,
+                    size = ButtonSize.Large,
+                    semantic = confirmSemantic,
+            )
+
+            if (altActionText != null) {
+                Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = altActionText,
+                        onClick = onAltActionClick,
+                        size = ButtonSize.Large,
+                        semantic = ButtonSemantic.Secondary,
+                )
+            }
+
+            Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = cancelText,
+                    onClick = onCancelClick,
+                    size = ButtonSize.Large,
+                    semantic = ButtonSemantic.Secondary,
+            )
+        }
+    } else {
+        Row(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = ConfirmModalButtonsTopPadding),
+                horizontalArrangement = Arrangement.spacedBy(ConfirmModalHorizontalButtonGap),
+        ) {
+            Button(
+                    modifier = Modifier.weight(1f),
+                    text = cancelText,
+                    onClick = onCancelClick,
+                    size = ButtonSize.Large,
+                    semantic = ButtonSemantic.Secondary,
+            )
+
+            Button(
+                    modifier = Modifier.weight(1f),
+                    text = confirmText,
+                    onClick = onConfirmClick,
+                    size = ButtonSize.Large,
+                    semantic = confirmSemantic,
+            )
+        }
+    }
+}
+
+private val ConfirmModalContentGap: Dp = 10.dp
+private val ConfirmModalContentBottomPadding: Dp = 8.dp
+private val ConfirmModalButtonsTopPadding: Dp = 12.dp
+private val ConfirmModalHorizontalButtonGap: Dp = 8.dp
+private val ConfirmModalVerticalButtonGap: Dp = 10.dp
+
+@Composable
+private fun ConfirmModalPreviewContent(
+        destructive: Boolean,
+        buttonLayout: ConfirmModalButtonLayout,
+        altActionText: String? = null,
+) {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(vertical = 24.dp),
+        ) {
+            ModalLayout {
+                ConfirmModalContent(
+                        title = "Dialog Title",
+                        description = "Description text goes here.",
+                )
+
+                ConfirmModalButtons(
+                        confirmText = if (destructive) "Delete" else "Confirm",
+                        onConfirmClick = {},
+                        cancelText = "Cancel",
+                        onCancelClick = {},
+                        altActionText = altActionText,
+                        onAltActionClick = {},
+                        destructive = destructive,
+                        buttonLayout = buttonLayout,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConfirmModalHorizontalPreview() = ConfirmModalPreviewContent(
+        destructive = false,
+        buttonLayout = ConfirmModalButtonLayout.Horizontal,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun ConfirmModalHorizontalDestructivePreview() = ConfirmModalPreviewContent(
+        destructive = true,
+        buttonLayout = ConfirmModalButtonLayout.Horizontal,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun ConfirmModalVerticalPreview() = ConfirmModalPreviewContent(
+        destructive = false,
+        buttonLayout = ConfirmModalButtonLayout.Vertical,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun ConfirmModalAltActionPreview() = ConfirmModalPreviewContent(
+        destructive = true,
+        buttonLayout = ConfirmModalButtonLayout.Vertical,
+        altActionText = "Alt Action",
+)
+
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun ConfirmModalDarkPreview() = ConfirmModalPreviewContent(
+        destructive = false,
+        buttonLayout = ConfirmModalButtonLayout.Horizontal,
+)

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Modal.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Modal.kt
@@ -52,7 +52,7 @@ fun Modal(
 }
 
 @Composable
-private fun ModalLayout(
+internal fun ModalLayout(
         modifier: Modifier = Modifier,
         content: @Composable ColumnScope.() -> Unit,
 ) {

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Modal.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Modal.kt
@@ -1,0 +1,131 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.typography.BezierTypo
+
+@Composable
+fun Modal(
+        onDismissRequest: () -> Unit,
+        modifier: Modifier = Modifier,
+        cancellable: Boolean = true,
+        content: @Composable ColumnScope.() -> Unit,
+) {
+    val properties = remember(cancellable) {
+        DialogProperties(
+                dismissOnBackPress = cancellable,
+                dismissOnClickOutside = cancellable,
+                usePlatformDefaultWidth = false,
+        )
+    }
+
+    Dialog(
+            onDismissRequest = onDismissRequest,
+            properties = properties,
+    ) {
+        ModalLayout(
+                modifier = modifier,
+                content = content,
+        )
+    }
+}
+
+@Composable
+private fun ModalLayout(
+        modifier: Modifier = Modifier,
+        content: @Composable ColumnScope.() -> Unit,
+) {
+    val elevationColor = BezierTheme.colorsV3.elevationLarge
+    val shadow = remember(elevationColor) {
+        Shadow(
+                radius = ModalShadowRadius,
+                color = elevationColor,
+                spread = ModalShadowSpread,
+                offset = DpOffset(0.dp, ModalShadowOffsetY),
+        )
+    }
+
+    Column(
+            modifier = modifier
+                    .padding(horizontal = ModalScreenHorizontalMargin)
+                    .widthIn(max = ModalMaxWidth)
+                    .fillMaxWidth()
+                    .dropShadow(
+                            shape = ModalShape,
+                            shadow = shadow,
+                    )
+                    .clip(ModalShape)
+                    .background(BezierTheme.colorsV3.surfaceHigher)
+                    .padding(
+                            start = ModalHorizontalPadding,
+                            top = ModalTopPadding,
+                            end = ModalHorizontalPadding,
+                            bottom = ModalBottomPadding,
+                    ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            content = content,
+    )
+}
+
+private val ModalMaxWidth: Dp = 480.dp
+private val ModalScreenHorizontalMargin: Dp = 40.dp
+private val ModalCornerRadius: Dp = 32.dp
+private val ModalHorizontalPadding: Dp = 16.dp
+private val ModalTopPadding: Dp = 20.dp
+private val ModalBottomPadding: Dp = 16.dp
+private val ModalShadowRadius: Dp = 20.dp
+private val ModalShadowSpread: Dp = 0.dp
+private val ModalShadowOffsetY: Dp = 4.dp
+private val ModalShape = RoundedCornerShape(ModalCornerRadius)
+
+@Composable
+private fun ModalPreviewContent() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(vertical = 32.dp),
+        ) {
+            ModalLayout {
+                BezierText(
+                        modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 40.dp),
+                        text = "customContent",
+                        typo = BezierTypo.TextMedium,
+                        color = BezierTheme.colorsV3.textNeutral,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ModalPreview() = ModalPreviewContent()
+
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun ModalDarkPreview() = ModalPreviewContent()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -45,6 +45,8 @@ import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ItemsPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ItemsPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.ModalPlaygroundKey
+import io.channel.bezier.compose.sample.playground.ModalPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SectionPlaygroundKey
@@ -107,6 +109,7 @@ private fun PlaygroundApp() {
                                     onSelectFloatingBanner = { backStack.add(FloatingBannerPlaygroundKey) },
                                     onSelectItems = { backStack.add(ItemsPlaygroundKey) },
                                     onSelectTextArea = { backStack.add(TextAreaPlaygroundKey) },
+                                    onSelectModal = { backStack.add(ModalPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -171,6 +174,9 @@ private fun PlaygroundApp() {
                         }
                         entry<TextAreaPlaygroundKey> {
                             TextAreaPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<ModalPlaygroundKey> {
+                            ModalPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -45,6 +45,8 @@ import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ItemsPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ItemsPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.ConfirmModalPlaygroundKey
+import io.channel.bezier.compose.sample.playground.ConfirmModalPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ModalPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ModalPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundKey
@@ -110,6 +112,7 @@ private fun PlaygroundApp() {
                                     onSelectItems = { backStack.add(ItemsPlaygroundKey) },
                                     onSelectTextArea = { backStack.add(TextAreaPlaygroundKey) },
                                     onSelectModal = { backStack.add(ModalPlaygroundKey) },
+                                    onSelectConfirmModal = { backStack.add(ConfirmModalPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -177,6 +180,9 @@ private fun PlaygroundApp() {
                         }
                         entry<ModalPlaygroundKey> {
                             ModalPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<ConfirmModalPlaygroundKey> {
+                            ConfirmModalPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -38,6 +38,7 @@ fun ComponentListScreen(
         onSelectFloatingBanner: () -> Unit,
         onSelectItems: () -> Unit,
         onSelectTextArea: () -> Unit,
+        onSelectModal: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -93,6 +94,8 @@ fun ComponentListScreen(
             ComponentRow("Items", onClick = onSelectItems)
             Divider()
             ComponentRow("TextArea", onClick = onSelectTextArea)
+            Divider()
+            ComponentRow("Modal", onClick = onSelectModal)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -39,6 +39,7 @@ fun ComponentListScreen(
         onSelectItems: () -> Unit,
         onSelectTextArea: () -> Unit,
         onSelectModal: () -> Unit,
+        onSelectConfirmModal: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -96,6 +97,8 @@ fun ComponentListScreen(
             ComponentRow("TextArea", onClick = onSelectTextArea)
             Divider()
             ComponentRow("Modal", onClick = onSelectModal)
+            Divider()
+            ComponentRow("ConfirmModal", onClick = onSelectConfirmModal)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ConfirmModalPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ConfirmModalPlaygroundScreen.kt
@@ -1,0 +1,125 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.v3.component.Button
+import io.channel.bezier.v3.component.ConfirmModal
+import io.channel.bezier.v3.component.ConfirmModalButtonLayout
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun ConfirmModalPlaygroundScreen(onBack: () -> Unit) {
+    var visible by remember { mutableStateOf(false) }
+    var buttonLayout by remember { mutableStateOf(ConfirmModalButtonLayout.Horizontal) }
+    var destructive by remember { mutableStateOf(false) }
+    var hasDescription by remember { mutableStateOf(true) }
+    var hasAltAction by remember { mutableStateOf(false) }
+    var hasCustomContent by remember { mutableStateOf(false) }
+    var cancellable by remember { mutableStateOf(true) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("ConfirmModal") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Button(
+                        text = "Open ConfirmModal",
+                        onClick = { visible = true },
+                )
+            }
+
+            Divider()
+
+            EnumControl(
+                    label = "buttonLayout",
+                    options = ConfirmModalButtonLayout.values(),
+                    selected = buttonLayout,
+            ) { buttonLayout = it }
+            BooleanControl("destructive", destructive) { destructive = it }
+            BooleanControl("hasDescription", hasDescription) { hasDescription = it }
+            BooleanControl("hasAltAction", hasAltAction) { hasAltAction = it }
+            BooleanControl("hasCustomContent", hasCustomContent) { hasCustomContent = it }
+            BooleanControl("cancellable", cancellable) { cancellable = it }
+        }
+    }
+
+    if (visible) {
+        ConfirmModal(
+                title = "Dialog Title",
+                confirmText = if (destructive) "Delete" else "Confirm",
+                onConfirmClick = { visible = false },
+                cancelText = "Cancel",
+                onCancelClick = { visible = false },
+                onDismissRequest = { visible = false },
+                description = "Description text goes here.".takeIf { hasDescription },
+                altActionText = "Alt Action".takeIf { hasAltAction },
+                onAltActionClick = { visible = false },
+                destructive = destructive,
+                buttonLayout = buttonLayout,
+                cancellable = cancellable,
+                customContent = if (hasCustomContent) {
+                    {
+                        BezierText(
+                                modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 12.dp),
+                                text = "customContent slot",
+                                typo = BezierTypo.TextMedium,
+                                color = BezierTheme.colorsV3.textNeutralLight,
+                        )
+                    }
+                } else {
+                    null
+                },
+        )
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ModalPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ModalPlaygroundScreen.kt
@@ -1,0 +1,108 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.v3.component.Button
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.Modal
+
+private const val ShortContent = "customContent"
+
+private const val LongContent =
+        "customContent 슬롯은 가로를 가득 채우고, 컨테이너 높이는 이 내용의 높이가 결정합니다. 문장이 길어지면 Modal도 함께 늘어납니다."
+
+@Composable
+fun ModalPlaygroundScreen(onBack: () -> Unit) {
+    var visible by remember { mutableStateOf(false) }
+    var cancellable by remember { mutableStateOf(true) }
+    var longContent by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Modal") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+            ) {
+                Button(
+                        text = "Open Modal",
+                        onClick = { visible = true },
+                )
+            }
+
+            Divider()
+
+            BooleanControl("Cancellable", cancellable) { cancellable = it }
+            BooleanControl("Long content", longContent) { longContent = it }
+        }
+    }
+
+    if (visible) {
+        Modal(
+                onDismissRequest = { visible = false },
+                cancellable = cancellable,
+        ) {
+            BezierText(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 20.dp),
+                    text = if (longContent) LongContent else ShortContent,
+                    typo = BezierTypo.TextMedium,
+                    color = BezierTheme.colorsV3.textNeutral,
+            )
+
+            Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Close",
+                    onClick = { visible = false },
+            )
+        }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -22,3 +22,4 @@ data object CheckboxPlaygroundKey
 data object FloatingBannerPlaygroundKey
 data object ItemsPlaygroundKey
 data object TextAreaPlaygroundKey
+data object ModalPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -23,3 +23,4 @@ data object FloatingBannerPlaygroundKey
 data object ItemsPlaygroundKey
 data object TextAreaPlaygroundKey
 data object ModalPlaygroundKey
+data object ConfirmModalPlaygroundKey


### PR DESCRIPTION
## 개요
Figma Modal([node 5325:11895](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5325-11895&m=dev))과 ConfirmModal([node 2420:477](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2420-477&m=dev))을 v3 패키지에 구현합니다. ConfirmModal은 Modal을 컨테이너로 재사용합니다.

## 변경 사항

### Modal — 껍데기 다이얼로그
- `io.channel.bezier.v3.component.Modal` — `Dialog` 내장 + content 슬롯만 갖는 컨테이너
- 배경 `surfaceHigher`, corner radius 32, padding top 20 / bottom 16 / horizontal 16
- `Elevation/Mobile/3` → `dropShadow(radius 20, offset (0, 4), spread 0, elevationLarge)`
- 너비 `min(화면너비 − 80, 480)` — Figma description의 너비 정책(양쪽 마진 40 · 상한 480)
- `cancellable`로 back press / outside click dismiss 제어

### ConfirmModal
- `io.channel.bezier.v3.component.ConfirmModal` — content(title + description) / customContent / buttons 조립
- `ConfirmModalButtonLayout { Horizontal, Vertical }` — **기본값 `Horizontal`**
  - `horizontal`: Cancel 좌 / Confirm 우, 균등 분할, 간격 8
  - `vertical`: Confirm → Alt Action → Cancel, 간격 10
- `altActionText`는 `vertical`에서만 렌더 (Figma codegen `isVertical && hasAltAction`, layout 자동 전환 없음)
- `destructive`면 Confirm이 `ButtonSemantic.Destructive`(`fillAccentRedHeavier`), 아니면 `.Primary`(`fillNeutralHeaviest`)
- title `BezierTypo.HeadingXSmall` / description `BezierTypo.TextLarge` + Regular, 둘 다 중앙 정렬

### 공통
- 기존 컴포넌트 재사용(최적화): `Modal`(ConfirmModal 컨테이너) · `Button`(`ButtonSize.Large` + `ButtonVariant.Filled`) · `BezierText`
- v3 컬러 토큰만 사용: `surfaceHigher` / `elevationLarge` / `textNeutral` / `fillNeutralHeaviest` / `fillAccentRedHeavier` / `fillNeutral` / `textInverse`
- `ModalShape`를 top-level `private val`로 올려 recomposition마다 `RoundedCornerShape` 재할당 제거, `DialogProperties`·`Shadow`는 `remember` 캐싱
- Preview가 컨테이너 스펙을 복제하지 않도록 `ModalLayout`을 `internal`로 노출
- 샘플 앱 플레이그라운드 추가 (Modal: cancellable / long content, ConfirmModal: buttonLayout / destructive / hasDescription / hasAltAction / hasCustomContent / cancellable)

## 검증
- `figma-component-spec` 사이클 두 컴포넌트 모두 완료: SPEC 작성 → 검증 7종(Properties / Layout / Color / Typography / Asset / Noise / 코드심볼) 통과 → Compose 구현 검증 통과
- 추가로 SPEC을 거치지 않는 **Figma ↔ 코드 직접 대조** 실행: Modal 스타일 값 14개 전수 일치·분기 0건, ConfirmModal Figma 조건 10개 ↔ Kotlin 분기 6개 1:1 대응, 조건 확장(`||`) 없음
- `:sample:assembleDebug` 성공, light/dark `@Preview` 포함

## 알려진 편차
- v3 `Button`의 `Large` 라벨 타이포가 Figma(weight 500 / letter-spacing 0)와 달리 `BezierWeight.Bold`(700) + letter-spacing −0.1로 고정입니다. 라벨 타이포는 `Button`의 SSOT 영역이라 ConfirmModal에서 우회하지 않았습니다.
- Figma 내부 모순 2건 — ConfirmModal description 본문의 "vertical(기본)" vs property 기본값 `horizontal`(후자 채택), `Typography/heading/xsmall`의 스타일명 "Semi Bold" vs weight 변수 700(후자 채택).

## 티켓
[MOB-6549](https://linear.app/channel/issue/MOB-6549)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 재사용 가능한 모달 및 확인 모달 컴포넌트를 추가했습니다.
  * 확인/취소/대체 액션, 파괴적 동작, 수평·수직 버튼 배치를 지원합니다.
  * 모달 닫기 조건과 사용자 지정 콘텐츠를 설정할 수 있습니다.
  * 샘플 앱에 모달 및 확인 모달 플레이그라운드를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->