### PR TITLE
v3 ConfirmModal cancel / alt action 옵셔널화

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/ConfirmModal.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/ConfirmModal.kt
@@ -29,11 +29,11 @@ fun ConfirmModal(
         title: String,
         confirmText: String,
         onConfirmClick: () -> Unit,
-        cancelText: String,
-        onCancelClick: () -> Unit,
         onDismissRequest: () -> Unit,
         modifier: Modifier = Modifier,
         description: String? = null,
+        cancelText: String? = null,
+        onCancelClick: () -> Unit = {},
         altActionText: String? = null,
         onAltActionClick: () -> Unit = {},
         destructive: Boolean = false,
@@ -108,7 +108,7 @@ private fun ConfirmModalContent(
 private fun ConfirmModalButtons(
         confirmText: String,
         onConfirmClick: () -> Unit,
-        cancelText: String,
+        cancelText: String?,
         onCancelClick: () -> Unit,
         altActionText: String?,
         onAltActionClick: () -> Unit,
@@ -143,13 +143,15 @@ private fun ConfirmModalButtons(
                 )
             }
 
-            Button(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = cancelText,
-                    onClick = onCancelClick,
-                    size = ButtonSize.Large,
-                    semantic = ButtonSemantic.Secondary,
-            )
+            if (cancelText != null) {
+                Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = cancelText,
+                        onClick = onCancelClick,
+                        size = ButtonSize.Large,
+                        semantic = ButtonSemantic.Secondary,
+                )
+            }
         }
     } else {
         Row(
@@ -158,13 +160,15 @@ private fun ConfirmModalButtons(
                         .padding(top = ConfirmModalButtonsTopPadding),
                 horizontalArrangement = Arrangement.spacedBy(ConfirmModalHorizontalButtonGap),
         ) {
-            Button(
-                    modifier = Modifier.weight(1f),
-                    text = cancelText,
-                    onClick = onCancelClick,
-                    size = ButtonSize.Large,
-                    semantic = ButtonSemantic.Secondary,
-            )
+            if (cancelText != null) {
+                Button(
+                        modifier = Modifier.weight(1f),
+                        text = cancelText,
+                        onClick = onCancelClick,
+                        size = ButtonSize.Large,
+                        semantic = ButtonSemantic.Secondary,
+                )
+            }
 
             Button(
                     modifier = Modifier.weight(1f),
@@ -187,6 +191,7 @@ private val ConfirmModalVerticalButtonGap: Dp = 10.dp
 private fun ConfirmModalPreviewContent(
         destructive: Boolean,
         buttonLayout: ConfirmModalButtonLayout,
+        cancelText: String? = "Cancel",
         altActionText: String? = null,
 ) {
     BezierTheme {
@@ -205,7 +210,7 @@ private fun ConfirmModalPreviewContent(
                 ConfirmModalButtons(
                         confirmText = if (destructive) "Delete" else "Confirm",
                         onConfirmClick = {},
-                        cancelText = "Cancel",
+                        cancelText = cancelText,
                         onCancelClick = {},
                         altActionText = altActionText,
                         onAltActionClick = {},
@@ -243,6 +248,23 @@ private fun ConfirmModalVerticalPreview() = ConfirmModalPreviewContent(
 private fun ConfirmModalAltActionPreview() = ConfirmModalPreviewContent(
         destructive = true,
         buttonLayout = ConfirmModalButtonLayout.Vertical,
+        altActionText = "Alt Action",
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun ConfirmModalConfirmOnlyPreview() = ConfirmModalPreviewContent(
+        destructive = false,
+        buttonLayout = ConfirmModalButtonLayout.Horizontal,
+        cancelText = null,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun ConfirmModalVerticalAltActionWithoutCancelPreview() = ConfirmModalPreviewContent(
+        destructive = false,
+        buttonLayout = ConfirmModalButtonLayout.Vertical,
+        cancelText = null,
         altActionText = "Alt Action",
 )
 

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ConfirmModalPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ConfirmModalPlaygroundScreen.kt
@@ -38,6 +38,7 @@ fun ConfirmModalPlaygroundScreen(onBack: () -> Unit) {
     var buttonLayout by remember { mutableStateOf(ConfirmModalButtonLayout.Horizontal) }
     var destructive by remember { mutableStateOf(false) }
     var hasDescription by remember { mutableStateOf(true) }
+    var hasCancel by remember { mutableStateOf(true) }
     var hasAltAction by remember { mutableStateOf(false) }
     var hasCustomContent by remember { mutableStateOf(false) }
     var cancellable by remember { mutableStateOf(true) }
@@ -86,6 +87,7 @@ fun ConfirmModalPlaygroundScreen(onBack: () -> Unit) {
             ) { buttonLayout = it }
             BooleanControl("destructive", destructive) { destructive = it }
             BooleanControl("hasDescription", hasDescription) { hasDescription = it }
+            BooleanControl("hasCancel", hasCancel) { hasCancel = it }
             BooleanControl("hasAltAction", hasAltAction) { hasAltAction = it }
             BooleanControl("hasCustomContent", hasCustomContent) { hasCustomContent = it }
             BooleanControl("cancellable", cancellable) { cancellable = it }
@@ -97,10 +99,10 @@ fun ConfirmModalPlaygroundScreen(onBack: () -> Unit) {
                 title = "Dialog Title",
                 confirmText = if (destructive) "Delete" else "Confirm",
                 onConfirmClick = { visible = false },
-                cancelText = "Cancel",
-                onCancelClick = { visible = false },
                 onDismissRequest = { visible = false },
                 description = "Description text goes here.".takeIf { hasDescription },
+                cancelText = "Cancel".takeIf { hasCancel },
+                onCancelClick = { visible = false },
                 altActionText = "Alt Action".takeIf { hasAltAction },
                 onAltActionClick = { visible = false },
                 destructive = destructive,


### PR DESCRIPTION
## 개요
v3 `ConfirmModal`에서 confirm 버튼만 필수로 두고, cancel과 alt action은 선택적으로 받도록 변경합니다. 지금까지는 `cancelText` / `onCancelClick`이 필수라 버튼이 최소 2개였습니다.

## 변경 사항

### 시그니처 — cancel 옵셔널화
```diff
 fun ConfirmModal(
         title: String,
         confirmText: String,
         onConfirmClick: () -> Unit,
-        cancelText: String,
-        onCancelClick: () -> Unit,
         onDismissRequest: () -> Unit,
         modifier: Modifier = Modifier,
         description: String? = null,
+        cancelText: String? = null,
+        onCancelClick: () -> Unit = {},
         altActionText: String? = null,
         onAltActionClick: () -> Unit = {},
```

- 필수 파라미터는 `title` / `confirmText` / `onConfirmClick` / `onDismissRequest` 4개
- 옵셔널이 된 두 파라미터를 `modifier` 뒤로 이동 — v3 `Button`, `Banner`, `FloatingBanner` 모두 `필수 → modifier → 옵셔널` 순서를 따릅니다
- 핸들러는 같은 파일의 `onAltActionClick: () -> Unit = {}` 패턴을 그대로 사용하고, 렌더 여부는 텍스트 null 여부로 판정합니다

### 버튼 렌더 조건
- **confirm**: 항상 렌더. `destructive`에 따라 `ButtonSemantic.Primary` / `.Destructive`
- **cancel**: `cancelText != null`
- **alt action**: `buttonLayout == Vertical && altActionText != null` — 기존 규칙 유지

| buttonLayout | cancel | altAction | 렌더 결과 |
|---|---|---|---|
| horizontal | ✗ | ✗ | Confirm |
| horizontal | ✗ | ✓ | Confirm — alt 무시 |
| horizontal | ✓ | ✗ | Cancel · Confirm |
| horizontal | ✓ | ✓ | Cancel · Confirm — alt 무시 |
| vertical | ✗ | ✗ | Confirm |
| vertical | ✗ | ✓ | Confirm → Alt Action |
| vertical | ✓ | ✗ | Confirm → Cancel |
| vertical | ✓ | ✓ | Confirm → Alt Action → Cancel |

Figma 가이드의 "horizontal + hasAltAction 금지 — 3버튼은 항상 vertical"을 그대로 지켜, horizontal에서는 버튼 개수와 무관하게 alt action을 무시합니다. 따라서 `horizontal`에 cancel 없이 alt action만 넘기면 confirm 하나만 남습니다.

버튼이 confirm 하나뿐이면 `horizontal`(`Row` 단일 자식 `weight(1f)`)과 `vertical`(`Column` 자식 `fillMaxWidth()`)의 결과가 같습니다 — 폭을 가득 채운 버튼 1개.

### 프리뷰 · 플레이그라운드
- `ConfirmModalConfirmOnlyPreview` — horizontal 단일 버튼
- `ConfirmModalVerticalAltActionWithoutCancelPreview` — vertical, cancel 없이 confirm + alt action
- 플레이그라운드에 `hasCancel` 토글 추가 (기본 on)

## ⚠️ Breaking change
`cancelText` / `onCancelClick`의 파라미터 위치가 바뀝니다. **위치 인자(positional)로 호출하던 코드는 컴파일이 깨집니다.** 이름 인자로 호출한 코드는 영향이 없습니다. 리포지토리 내 호출부는 플레이그라운드 1곳뿐이고 함께 수정했습니다.

## 검증
- `:bezier:compileDebugKotlin`, `:sample:compileDebugKotlin`, `:sample:assembleDebug` 모두 성공
- 플레이그라운드에서 위 매트릭스 8개 조합 확인 가능 (`buttonLayout` × `hasCancel` × `hasAltAction`)

## 티켓
이 변경에 대응하는 Linear 티켓이 없습니다. 원래 구현 티켓([MOB-6549](https://linear.app/channel/issue/MOB-6549))은 이미 Done 상태입니다.

## 스펙 문서
`docs/v3/ConfirmModal/SPEC.md` §10(Figma 밖 구현 결정)에 cancel 옵셔널화 · 파라미터 순서 · 버튼 렌더 조건 매트릭스를 기록했습니다. `docs/`는 `.gitignore` 대상이라 이 PR의 diff에는 포함되지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 확인 모달에서 취소 버튼을 선택적으로 표시할 수 있습니다.
  * 취소 문구를 제공하지 않으면 확인 버튼만 표시됩니다.
  * 세로·가로 레이아웃 모두에서 취소 버튼 표시 여부가 일관되게 적용됩니다.
  * 모달을 닫는 동작을 간편하게 설정할 수 있도록 사용 방식이 개선되었습니다.
  * 플레이그라운드에서 취소 버튼 표시 여부를 직접 전환하며 미리 볼 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->