### PR TITLE
컴포넌트 인터랙션 통지 훅 (BezierComponentInteraction)

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/component/Banner.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Banner.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
+import io.channel.bezier.interaction.BezierComponentInteraction
 
 @Composable
 fun Banner(
@@ -85,6 +86,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
+            label = null,
             description = {
                 Text(
                         text = description,
@@ -121,6 +123,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
+            label = description,
             description = {
                 Text(
                         text = description,
@@ -154,6 +157,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
+            label = null,
             description = {
                 Text(
                         text = description,
@@ -187,6 +191,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
+            label = description,
             description = {
                 Text(
                         text = description,
@@ -208,6 +213,7 @@ fun Banner(
 @Composable
 private fun BannerLayout(
         type: BannerType,
+        label: String?,
         description: @Composable () -> Unit,
         modifier: Modifier,
         title: String?,
@@ -235,7 +241,10 @@ private fun BannerLayout(
                     .background(colorResource(id = type.backgroundColor))
                     .let {
                         if (onClick != null) {
-                            it.clickable(onClick = onClick)
+                            it.clickable {
+                                BezierComponentInteraction.notify("BannerV1", label)
+                                onClick.invoke()
+                            }
                         } else {
                             it
                         }
@@ -288,7 +297,10 @@ private fun BannerLayout(
                             .clickable(
                                     interactionSource = remember { MutableInteractionSource() },
                                     indication = null,
-                                    onClick = onRemove,
+                                    onClick = {
+                                        BezierComponentInteraction.notify("BannerV1", null)
+                                        onRemove.invoke()
+                                    },
                             )
                             .padding(5.dp),
                     painter = painterResource(id = R.drawable.icon_cancel_small),

--- a/bezier/src/main/java/io/channel/bezier/component/Banner.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Banner.kt
@@ -86,7 +86,6 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            descriptionText = null,
             description = {
                 Text(
                         text = description,
@@ -99,7 +98,12 @@ fun Banner(
             leftIcon = icon,
             leftIconColor = iconColor,
             rightIcon = null,
-            onClick = onClick,
+            onClick = onClick?.let { original ->
+                {
+                    BezierComponentInteraction.notify("Banner", "V1", null)
+                    original.invoke()
+                }
+            },
             onRemove = onRemove,
             content = content,
     )
@@ -123,7 +127,6 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            descriptionText = description,
             description = {
                 Text(
                         text = description,
@@ -136,7 +139,12 @@ fun Banner(
             leftIcon = icon,
             leftIconColor = iconColor,
             rightIcon = null,
-            onClick = onClick,
+            onClick = onClick?.let { original ->
+                {
+                    BezierComponentInteraction.notify("Banner", "V1", description)
+                    original.invoke()
+                }
+            },
             onRemove = onRemove,
             content = content,
     )
@@ -157,7 +165,6 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            descriptionText = null,
             description = {
                 Text(
                         text = description,
@@ -170,7 +177,12 @@ fun Banner(
             leftIcon = leftIcon,
             leftIconColor = leftIconColor,
             rightIcon = rightIcon,
-            onClick = onClick,
+            onClick = onClick?.let { original ->
+                {
+                    BezierComponentInteraction.notify("Banner", "V1", null)
+                    original.invoke()
+                }
+            },
             onRemove = onRemove,
             content = content,
     )
@@ -191,7 +203,6 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            descriptionText = description,
             description = {
                 Text(
                         text = description,
@@ -204,7 +215,12 @@ fun Banner(
             leftIcon = leftIcon,
             leftIconColor = leftIconColor,
             rightIcon = rightIcon,
-            onClick = onClick,
+            onClick = onClick?.let { original ->
+                {
+                    BezierComponentInteraction.notify("Banner", "V1", description)
+                    original.invoke()
+                }
+            },
             onRemove = onRemove,
             content = content,
     )
@@ -213,7 +229,6 @@ fun Banner(
 @Composable
 private fun BannerLayout(
         type: BannerType,
-        descriptionText: String?,
         description: @Composable () -> Unit,
         modifier: Modifier,
         title: String?,
@@ -241,10 +256,7 @@ private fun BannerLayout(
                     .background(colorResource(id = type.backgroundColor))
                     .let {
                         if (onClick != null) {
-                            it.clickable {
-                                BezierComponentInteraction.notify("Banner", "V1", descriptionText)
-                                onClick.invoke()
-                            }
+                            it.clickable(onClick = onClick)
                         } else {
                             it
                         }

--- a/bezier/src/main/java/io/channel/bezier/component/Banner.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Banner.kt
@@ -86,7 +86,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            label = null,
+            descriptionText = null,
             description = {
                 Text(
                         text = description,
@@ -123,7 +123,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            label = description,
+            descriptionText = description,
             description = {
                 Text(
                         text = description,
@@ -157,7 +157,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            label = null,
+            descriptionText = null,
             description = {
                 Text(
                         text = description,
@@ -191,7 +191,7 @@ fun Banner(
 ) {
     BannerLayout(
             type = type,
-            label = description,
+            descriptionText = description,
             description = {
                 Text(
                         text = description,
@@ -213,7 +213,7 @@ fun Banner(
 @Composable
 private fun BannerLayout(
         type: BannerType,
-        label: String?,
+        descriptionText: String?,
         description: @Composable () -> Unit,
         modifier: Modifier,
         title: String?,
@@ -242,7 +242,7 @@ private fun BannerLayout(
                     .let {
                         if (onClick != null) {
                             it.clickable {
-                                BezierComponentInteraction.notify("Banner", "V1", label)
+                                BezierComponentInteraction.notify("Banner", "V1", descriptionText)
                                 onClick.invoke()
                             }
                         } else {

--- a/bezier/src/main/java/io/channel/bezier/component/Banner.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Banner.kt
@@ -242,7 +242,7 @@ private fun BannerLayout(
                     .let {
                         if (onClick != null) {
                             it.clickable {
-                                BezierComponentInteraction.notify("BannerV1", label)
+                                BezierComponentInteraction.notify("Banner", "V1", label)
                                 onClick.invoke()
                             }
                         } else {
@@ -298,7 +298,7 @@ private fun BannerLayout(
                                     interactionSource = remember { MutableInteractionSource() },
                                     indication = null,
                                     onClick = {
-                                        BezierComponentInteraction.notify("BannerV1", null)
+                                        BezierComponentInteraction.notify("Banner", "V1", null)
                                         onRemove.invoke()
                                     },
                             )

--- a/bezier/src/main/java/io/channel/bezier/component/Button.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Button.kt
@@ -78,7 +78,7 @@ fun Button(
                             indication = indication,
                             enabled = enabled,
                     ) {
-                        BezierComponentInteraction.notify("ButtonV1", text)
+                        BezierComponentInteraction.notify("Button", "V1", text)
                         onClick.invoke()
                     }
                     .padding(

--- a/bezier/src/main/java/io/channel/bezier/component/Button.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Button.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
+import io.channel.bezier.interaction.BezierComponentInteraction
 
 @Composable
 fun Button(
@@ -77,6 +78,7 @@ fun Button(
                             indication = indication,
                             enabled = enabled,
                     ) {
+                        BezierComponentInteraction.notify("ButtonV1", text)
                         onClick.invoke()
                     }
                     .padding(

--- a/bezier/src/main/java/io/channel/bezier/component/Checkbox.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Checkbox.kt
@@ -33,6 +33,7 @@ import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
 import io.channel.bezier.extension.ifTrue
 import io.channel.bezier.extension.orElse
+import io.channel.bezier.interaction.BezierComponentInteraction
 
 typealias CheckboxType = Checkbox.Type
 typealias CheckboxState = Checkbox.State
@@ -181,6 +182,7 @@ fun Checkbox(
                             indication = null,
                             enabled = enabled,
                     ) {
+                        BezierComponentInteraction.notify("CheckboxV1", text)
                         onStateChange(state.toggle())
                     },
             verticalAlignment = Alignment.CenterVertically,
@@ -200,6 +202,7 @@ fun Checkbox(
                                 indication = ripple(),
                                 enabled = enabled,
                         ) {
+                            BezierComponentInteraction.notify("CheckboxV1", text)
                             onStateChange(state.toggle())
                         },
         ) {

--- a/bezier/src/main/java/io/channel/bezier/component/Checkbox.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Checkbox.kt
@@ -182,7 +182,7 @@ fun Checkbox(
                             indication = null,
                             enabled = enabled,
                     ) {
-                        BezierComponentInteraction.notify("CheckboxV1", text)
+                        BezierComponentInteraction.notify("Checkbox", "V1", text)
                         onStateChange(state.toggle())
                     },
             verticalAlignment = Alignment.CenterVertically,
@@ -202,7 +202,7 @@ fun Checkbox(
                                 indication = ripple(),
                                 enabled = enabled,
                         ) {
-                            BezierComponentInteraction.notify("CheckboxV1", text)
+                            BezierComponentInteraction.notify("Checkbox", "V1", text)
                             onStateChange(state.toggle())
                         },
         ) {

--- a/bezier/src/main/java/io/channel/bezier/component/ListItemContainer.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/ListItemContainer.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.semantics.semantics
 import io.channel.bezier.compose.R
+import io.channel.bezier.interaction.bezierComponent
 import kotlin.math.max
 
 @Composable
@@ -53,6 +55,7 @@ fun ListItemContainer(
 ) {
     Column(
             modifier = modifier
+                    .semantics { bezierComponent = "ListItemContainer" }
                     .fillMaxWidth()
                     .heightIn(min = size.minHeight)
                     .padding(start = 6.dp)

--- a/bezier/src/main/java/io/channel/bezier/component/OutlineItem.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/OutlineItem.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
+import io.channel.bezier.interaction.BezierComponentInteraction
 
 private val IndentWidth = 12.dp
 
@@ -47,7 +48,10 @@ fun OutlineItem(
                                 enabled = onClickExpand != null && toggle != OutlineToggle.Leaf,
                                 indication = ripple(radius = 12.dp),
                                 interactionSource = remember { MutableInteractionSource() },
-                                onClick = { onClickExpand?.invoke() },
+                                onClick = {
+                                    BezierComponentInteraction.notify("OutlineItemV1", null)
+                                    onClickExpand?.invoke()
+                                },
                         )
                         .padding(6.dp)
                         .size(24.dp)

--- a/bezier/src/main/java/io/channel/bezier/component/OutlineItem.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/OutlineItem.kt
@@ -49,7 +49,7 @@ fun OutlineItem(
                                 indication = ripple(radius = 12.dp),
                                 interactionSource = remember { MutableInteractionSource() },
                                 onClick = {
-                                    BezierComponentInteraction.notify("OutlineItemV1", null)
+                                    BezierComponentInteraction.notify("OutlineItem", "V1", null)
                                     onClickExpand?.invoke()
                                 },
                         )

--- a/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
@@ -20,8 +20,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.semantics.semantics
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
+import io.channel.bezier.interaction.bezierComponent
 
 @Composable
 fun SectionLabel(
@@ -33,6 +35,7 @@ fun SectionLabel(
 ) {
     Row(
             modifier = modifier
+                    .semantics { bezierComponent = "SectionLabel" }
                     .sizeIn(minHeight = 32.dp),
             verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/bezier/src/main/java/io/channel/bezier/component/Switch.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Switch.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.extension.roundedBackground
+import io.channel.bezier.interaction.BezierComponentInteraction
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
@@ -156,6 +157,7 @@ fun Switch(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null,
                     ) {
+                        BezierComponentInteraction.notify("SwitchV1", null)
                         coroutineScope.launch {
                             state.switch()
                         }

--- a/bezier/src/main/java/io/channel/bezier/component/Switch.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Switch.kt
@@ -157,7 +157,7 @@ fun Switch(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null,
                     ) {
-                        BezierComponentInteraction.notify("SwitchV1", null)
+                        BezierComponentInteraction.notify("Switch", "V1", null)
                         coroutineScope.launch {
                             state.switch()
                         }

--- a/bezier/src/main/java/io/channel/bezier/component/Tag.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Tag.kt
@@ -207,7 +207,7 @@ fun Tag(
                                     interactionSource = remember { MutableInteractionSource() },
                                     indication = null,
                                     onClick = {
-                                        BezierComponentInteraction.notify("TagV1", null)
+                                        BezierComponentInteraction.notify("Tag", "V1", null)
                                         onRemove.invoke()
                                     },
                             ),

--- a/bezier/src/main/java/io/channel/bezier/component/Tag.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/Tag.kt
@@ -43,6 +43,7 @@ import androidx.core.content.res.use
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
 import io.channel.bezier.extension.orElse
+import io.channel.bezier.interaction.BezierComponentInteraction
 
 typealias TagSize = Tag.Size
 typealias TagColor = Tag.Color
@@ -205,7 +206,10 @@ fun Tag(
                             .clickable(
                                     interactionSource = remember { MutableInteractionSource() },
                                     indication = null,
-                                    onClick = onRemove,
+                                    onClick = {
+                                        BezierComponentInteraction.notify("TagV1", null)
+                                        onRemove.invoke()
+                                    },
                             ),
                     painter = painterResource(id = R.drawable.icon_cancel),
                     contentDescription = null,

--- a/bezier/src/main/java/io/channel/bezier/component/TextField.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/TextField.kt
@@ -216,7 +216,7 @@ fun TextField(
                                                     } else {
                                                         BezierIcons.ViewOff
                                                     }
-                                                    BezierComponentInteraction.notify("TextFieldV1", toggleIcon.imageVector.name)
+                                                    BezierComponentInteraction.notify("TextField", "V1", toggleIcon.imageVector.name)
                                                     isPasswordVisible = !isPasswordVisible
                                                 },
                                         ),
@@ -244,7 +244,7 @@ fun TextField(
                                                 interactionSource = remember { MutableInteractionSource() },
                                                 indication = null,
                                                 onClick = {
-                                                    BezierComponentInteraction.notify("TextFieldV1", BezierIcons.CancelCircleFilled.imageVector.name)
+                                                    BezierComponentInteraction.notify("TextField", "V1", BezierIcons.CancelCircleFilled.imageVector.name)
                                                     onValueChange(TextFieldValue())
                                                 },
                                         ),

--- a/bezier/src/main/java/io/channel/bezier/component/TextField.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/TextField.kt
@@ -62,6 +62,7 @@ import io.channel.bezier.icon.ChevronDown
 import io.channel.bezier.icon.Search
 import io.channel.bezier.icon.View
 import io.channel.bezier.icon.ViewOff
+import io.channel.bezier.interaction.BezierComponentInteraction
 
 val TextFieldOuterBorderWidth = 3.dp
 val TextFieldOuterBorderRadius = 8.dp + TextFieldOuterBorderWidth
@@ -210,6 +211,12 @@ fun TextField(
                                                 interactionSource = remember { MutableInteractionSource() },
                                                 indication = null,
                                                 onClick = {
+                                                    val toggleIcon = if (isPasswordVisible) {
+                                                        BezierIcons.View
+                                                    } else {
+                                                        BezierIcons.ViewOff
+                                                    }
+                                                    BezierComponentInteraction.notify("TextFieldV1", toggleIcon.imageVector.name)
                                                     isPasswordVisible = !isPasswordVisible
                                                 },
                                         ),
@@ -237,6 +244,7 @@ fun TextField(
                                                 interactionSource = remember { MutableInteractionSource() },
                                                 indication = null,
                                                 onClick = {
+                                                    BezierComponentInteraction.notify("TextFieldV1", BezierIcons.CancelCircleFilled.imageVector.name)
                                                     onValueChange(TextFieldValue())
                                                 },
                                         ),

--- a/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
+++ b/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
@@ -6,10 +6,10 @@ import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 object BezierComponentInteraction {
 
     @Volatile
-    var onComponentClick: ((component: String, label: String?) -> Unit)? = null
+    var onComponentClick: ((component: String, version: String?, label: String?) -> Unit)? = null
 
-    internal fun notify(component: String, label: String?) {
-        onComponentClick?.invoke(component, label)
+    internal fun notify(component: String, version: String?, label: String?) {
+        onComponentClick?.invoke(component, version, label)
     }
 }
 

--- a/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
+++ b/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
@@ -1,0 +1,21 @@
+package io.channel.bezier.interaction
+
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+
+object BezierComponentInteraction {
+
+    @Volatile
+    var onComponentClick: ((component: String, label: String?) -> Unit)? = null
+
+    internal fun notify(component: String, label: String?) {
+        onComponentClick?.invoke(component, label)
+    }
+}
+
+val BezierComponentKey = SemanticsPropertyKey<String>(
+        name = "BezierComponent",
+        mergePolicy = { parent, child -> parent ?: child },
+)
+
+var SemanticsPropertyReceiver.bezierComponent by BezierComponentKey

--- a/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
+++ b/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
@@ -9,7 +9,7 @@ object BezierComponentInteraction {
     var onComponentClick: ((component: String, version: String?, label: String?) -> Unit)? = null
 
     internal fun notify(component: String, version: String?, label: String?) {
-        onComponentClick?.invoke(component, version, label)
+        runCatching { onComponentClick?.invoke(component, version, label) }
     }
 }
 

--- a/bezier/src/main/java/io/channel/bezier/usecase/IconActionListItem.kt
+++ b/bezier/src/main/java/io/channel/bezier/usecase/IconActionListItem.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.semantics.semantics
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
 import io.channel.bezier.component.Badge
 import io.channel.bezier.component.ListItemContainer
 import io.channel.bezier.component.ListItemContainerSize
+import io.channel.bezier.interaction.bezierComponent
 
 @Composable
 fun IconActionListItem(
@@ -35,7 +37,7 @@ fun IconActionListItem(
         content: @Composable () -> Unit = {},
 ) {
     ListItemContainer(
-            modifier = modifier,
+            modifier = modifier.semantics { bezierComponent = "IconActionListItem" },
             size = size,
             leftContent = icon?.let {
                 {

--- a/bezier/src/main/java/io/channel/bezier/usecase/IconActionListItem.kt
+++ b/bezier/src/main/java/io/channel/bezier/usecase/IconActionListItem.kt
@@ -16,13 +16,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.semantics.semantics
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
 import io.channel.bezier.component.Badge
 import io.channel.bezier.component.ListItemContainer
 import io.channel.bezier.component.ListItemContainerSize
-import io.channel.bezier.interaction.bezierComponent
 
 @Composable
 fun IconActionListItem(
@@ -37,7 +35,7 @@ fun IconActionListItem(
         content: @Composable () -> Unit = {},
 ) {
     ListItemContainer(
-            modifier = modifier.semantics { bezierComponent = "IconActionListItem" },
+            modifier = modifier,
             size = size,
             leftContent = icon?.let {
                 {

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Banner.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Banner.kt
@@ -62,7 +62,7 @@ fun Banner(
                     .then(
                             if (onClick != null) {
                                 Modifier.clickable {
-                                    BezierComponentInteraction.notify("BannerV3", description)
+                                    BezierComponentInteraction.notify("Banner", "V3", description)
                                     onClick.invoke()
                                 }
                             } else {
@@ -114,7 +114,7 @@ fun Banner(
                                         Modifier
                                                 .clip(CircleShape)
                                                 .clickable {
-                                                    BezierComponentInteraction.notify("BannerV3", trailingIcon.imageVector.name)
+                                                    BezierComponentInteraction.notify("Banner", "V3", trailingIcon.imageVector.name)
                                                     onDismiss.invoke()
                                                 }
                                     } else {

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Banner.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Banner.kt
@@ -34,6 +34,7 @@ import io.channel.bezier.icon.ErrorDiamondFilled
 import io.channel.bezier.icon.Info
 import io.channel.bezier.icon.Lightbulb
 import io.channel.bezier.icon.Limit
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
 
@@ -60,7 +61,10 @@ fun Banner(
                     .background(colorSpec.background)
                     .then(
                             if (onClick != null) {
-                                Modifier.clickable(onClick = onClick)
+                                Modifier.clickable {
+                                    BezierComponentInteraction.notify("BannerV3", description)
+                                    onClick.invoke()
+                                }
                             } else {
                                 Modifier
                             }
@@ -109,7 +113,10 @@ fun Banner(
                                     if (onDismiss != null) {
                                         Modifier
                                                 .clip(CircleShape)
-                                                .clickable(onClick = onDismiss)
+                                                .clickable {
+                                                    BezierComponentInteraction.notify("BannerV3", trailingIcon.imageVector.name)
+                                                    onDismiss.invoke()
+                                                }
                                     } else {
                                         Modifier
                                     }

--- a/bezier/src/main/java/io/channel/bezier/v3/component/BaseItem.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/BaseItem.kt
@@ -18,12 +18,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
+import io.channel.bezier.interaction.bezierComponent
 import io.channel.bezier.typography.BezierTypo
 
 @Composable
@@ -38,6 +40,7 @@ fun BaseItem(
 ) {
     Row(
             modifier = modifier
+                    .semantics { bezierComponent = "BaseItem" }
                     .clip(RoundedCornerShape(BaseItemCornerRadius))
                     .heightIn(min = size.minHeight)
                     .padding(

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
@@ -39,6 +39,7 @@ import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.dimension.BezierLetterSpacing
 import io.channel.bezier.icon.Plus
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
 
@@ -88,7 +89,10 @@ fun Button(
                             interactionSource = interactionSource,
                             indication = null,
                             enabled = enabled && !isLoading,
-                            onClick = onClick,
+                            onClick = {
+                                BezierComponentInteraction.notify("ButtonV3", text)
+                                onClick()
+                            },
                     )
                     .padding(horizontal = spec.horizontalPadding),
             contentAlignment = Alignment.Center,

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
@@ -90,7 +90,7 @@ fun Button(
                             indication = null,
                             enabled = enabled && !isLoading,
                             onClick = {
-                                BezierComponentInteraction.notify("ButtonV3", text)
+                                BezierComponentInteraction.notify("Button", "V3", text)
                                 onClick()
                             },
                     )

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Checkbox.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Checkbox.kt
@@ -29,6 +29,7 @@ import io.channel.bezier.component.BezierText
 import io.channel.bezier.extension.outsideBorder
 import io.channel.bezier.icon.CheckBold
 import io.channel.bezier.icon.HyphenBold
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 
 @Composable
@@ -45,7 +46,10 @@ fun Checkbox(
     Row(
             modifier = modifier
                     .graphicsLayer(alpha = if (enabled) 1f else 0.4f)
-                    .clickable(enabled = enabled, onClick = onClick)
+                    .clickable(enabled = enabled) {
+                        BezierComponentInteraction.notify("CheckboxV3", label)
+                        onClick()
+                    }
                     .padding(vertical = CheckboxRowVerticalPadding),
             horizontalArrangement = Arrangement.spacedBy(CheckboxGap),
             verticalAlignment = Alignment.CenterVertically,

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Checkbox.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Checkbox.kt
@@ -47,7 +47,7 @@ fun Checkbox(
             modifier = modifier
                     .graphicsLayer(alpha = if (enabled) 1f else 0.4f)
                     .clickable(enabled = enabled) {
-                        BezierComponentInteraction.notify("CheckboxV3", label)
+                        BezierComponentInteraction.notify("Checkbox", "V3", label)
                         onClick()
                     }
                     .padding(vertical = CheckboxRowVerticalPadding),

--- a/bezier/src/main/java/io/channel/bezier/v3/component/CollapsibleSection.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/CollapsibleSection.kt
@@ -36,6 +36,7 @@ import io.channel.bezier.icon.ChevronSmallDown
 import io.channel.bezier.icon.ChevronSmallRight
 import io.channel.bezier.icon.Folder
 import io.channel.bezier.icon.Plus
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
 
@@ -84,7 +85,10 @@ private fun CollapsibleSectionLabel(
                     .clip(CollapsibleSectionLabelShape)
                     .then(
                             if (onOpenChange != null) {
-                                Modifier.clickable { onOpenChange(!open) }
+                                Modifier.clickable {
+                                    BezierComponentInteraction.notify("CollapsibleSection", "V3", label)
+                                    onOpenChange(!open)
+                                }
                             } else {
                                 Modifier
                             },

--- a/bezier/src/main/java/io/channel/bezier/v3/component/DropdownMenu.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/DropdownMenu.kt
@@ -67,6 +67,7 @@ import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.Plus
 import io.channel.bezier.icon.Trash
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
 
@@ -244,7 +245,10 @@ fun DropdownMenuItem(
                             interactionSource = interactionSource,
                             indication = null,
                             enabled = enabled,
-                            onClick = onClick,
+                            onClick = {
+                                BezierComponentInteraction.notify("DropdownMenuItem", "V3", label)
+                                onClick()
+                            },
                     )
                     .padding(
                             horizontal = ItemHorizontalPadding,

--- a/bezier/src/main/java/io/channel/bezier/v3/component/FloatingBanner.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/FloatingBanner.kt
@@ -32,6 +32,7 @@ import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.CancelSmall
 import io.channel.bezier.icon.ChevronSmallRight
 import io.channel.bezier.icon.Plus
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
 
@@ -64,7 +65,10 @@ fun FloatingBanner(
                     .background(colors.surfaceHighest)
                     .let {
                         if (clickArea == FloatingBannerClickArea.Full && onClick != null) {
-                            it.clickable(onClick = onClick)
+                            it.clickable {
+                                BezierComponentInteraction.notify("FloatingBannerV3", description)
+                                onClick.invoke()
+                            }
                         } else {
                             it
                         }
@@ -113,7 +117,10 @@ fun FloatingBanner(
                                 if (clickArea == FloatingBannerClickArea.ActionIcon && onClick != null) {
                                     it
                                             .clip(CircleShape)
-                                            .clickable(onClick = onClick)
+                                            .clickable {
+                                                BezierComponentInteraction.notify("FloatingBannerV3", actionIcon.imageVector.name)
+                                                onClick.invoke()
+                                            }
                                 } else {
                                     it
                                 }

--- a/bezier/src/main/java/io/channel/bezier/v3/component/FloatingBanner.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/FloatingBanner.kt
@@ -66,7 +66,7 @@ fun FloatingBanner(
                     .let {
                         if (clickArea == FloatingBannerClickArea.Full && onClick != null) {
                             it.clickable {
-                                BezierComponentInteraction.notify("FloatingBannerV3", description)
+                                BezierComponentInteraction.notify("FloatingBanner", "V3", description)
                                 onClick.invoke()
                             }
                         } else {
@@ -118,7 +118,7 @@ fun FloatingBanner(
                                     it
                                             .clip(CircleShape)
                                             .clickable {
-                                                BezierComponentInteraction.notify("FloatingBannerV3", actionIcon.imageVector.name)
+                                                BezierComponentInteraction.notify("FloatingBanner", "V3", actionIcon.imageVector.name)
                                                 onClick.invoke()
                                             }
                                 } else {

--- a/bezier/src/main/java/io/channel/bezier/v3/component/IconButton.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/IconButton.kt
@@ -73,7 +73,7 @@ fun IconButton(
                             indication = null,
                             enabled = enabled && !isLoading,
                             onClick = {
-                                BezierComponentInteraction.notify("IconButtonV3", icon.imageVector.name)
+                                BezierComponentInteraction.notify("IconButton", "V3", icon.imageVector.name)
                                 onClick()
                             },
                     ),

--- a/bezier/src/main/java/io/channel/bezier/v3/component/IconButton.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/IconButton.kt
@@ -34,6 +34,7 @@ import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.Plus
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 
 @Composable
@@ -71,7 +72,10 @@ fun IconButton(
                             interactionSource = interactionSource,
                             indication = null,
                             enabled = enabled && !isLoading,
-                            onClick = onClick,
+                            onClick = {
+                                BezierComponentInteraction.notify("IconButtonV3", icon.imageVector.name)
+                                onClick()
+                            },
                     ),
             contentAlignment = Alignment.Center,
     ) {

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Search.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Search.kt
@@ -42,6 +42,7 @@ import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.CancelCircleFilled
 import io.channel.bezier.icon.Search
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 
 private val Height = 40.dp
@@ -148,7 +149,10 @@ fun Search(
                                             .clickable(
                                                     interactionSource = remember { MutableInteractionSource() },
                                                     indication = null,
-                                                    onClick = { onValueChange("") },
+                                                    onClick = {
+                                                        BezierComponentInteraction.notify("Search", "V3", BezierIcons.CancelCircleFilled.imageVector.name)
+                                                        onValueChange("")
+                                                    },
                                             ),
                                     imageVector = BezierIcons.CancelCircleFilled.imageVector,
                                     contentDescription = null,
@@ -167,7 +171,10 @@ fun Search(
                                     interactionSource = remember { MutableInteractionSource() },
                                     indication = null,
                                     enabled = enabled,
-                                    onClick = onCancelClick,
+                                    onClick = {
+                                        BezierComponentInteraction.notify("Search", "V3", cancelText)
+                                        onCancelClick()
+                                    },
                             )
                             .padding(horizontal = CancelHorizontalPadding),
                     contentAlignment = Alignment.Center,

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -56,6 +58,7 @@ fun Switch(
         modifier: Modifier = Modifier,
         enabled: Boolean = true,
         hasError: Boolean = false,
+        contentDescription: String? = null,
         interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     val colors = BezierTheme.colorsV3
@@ -87,6 +90,12 @@ fun Switch(
     Box(
             modifier = modifier
                     .size(width = TrackWidth, height = TrackHeight)
+                    .then(
+                            when (contentDescription) {
+                                null -> Modifier
+                                else -> Modifier.semantics { this.contentDescription = contentDescription }
+                            },
+                    )
                     .then(errorBorderModifier)
                     .graphicsLayer { alpha = if (enabled) 1f else DisabledAlpha }
                     .drawBehind {
@@ -102,7 +111,7 @@ fun Switch(
                                         indication = null,
                                         enabled = enabled,
                                         onClick = {
-                                            BezierComponentInteraction.notify("Switch", "V3", null)
+                                            BezierComponentInteraction.notify("Switch", "V3", contentDescription)
                                             onCheckedChange(!checked)
                                         },
                                 )

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 
 private val TrackWidth = 50.dp
@@ -100,7 +101,10 @@ fun Switch(
                                         interactionSource = interactionSource,
                                         indication = null,
                                         enabled = enabled,
-                                        onClick = { onCheckedChange(!checked) },
+                                        onClick = {
+                                            BezierComponentInteraction.notify("SwitchV3", null)
+                                            onCheckedChange(!checked)
+                                        },
                                 )
                             } else {
                                 Modifier

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Switch.kt
@@ -102,7 +102,7 @@ fun Switch(
                                         indication = null,
                                         enabled = enabled,
                                         onClick = {
-                                            BezierComponentInteraction.notify("SwitchV3", null)
+                                            BezierComponentInteraction.notify("Switch", "V3", null)
                                             onCheckedChange(!checked)
                                         },
                                 )

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
@@ -29,6 +29,7 @@ import io.channel.bezier.BezierTheme
 import io.channel.bezier.color.BezierSemanticColorV3
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.CancelSmall
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
 
@@ -64,7 +65,10 @@ fun Tag(
                     modifier = Modifier
                             .size(TagCancelIconLength)
                             .clip(CircleShape)
-                            .clickable(onClick = onDelete),
+                            .clickable {
+                                BezierComponentInteraction.notify("TagV3", BezierIcons.CancelSmall.imageVector.name)
+                                onDelete.invoke()
+                            },
             ) {
                 Icon(
                         imageVector = BezierIcons.CancelSmall.imageVector,

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Tag.kt
@@ -66,7 +66,7 @@ fun Tag(
                             .size(TagCancelIconLength)
                             .clip(CircleShape)
                             .clickable {
-                                BezierComponentInteraction.notify("TagV3", BezierIcons.CancelSmall.imageVector.name)
+                                BezierComponentInteraction.notify("Tag", "V3", BezierIcons.CancelSmall.imageVector.name)
                                 onDelete.invoke()
                             },
             ) {

--- a/bezier/src/main/java/io/channel/bezier/v3/component/TextInput.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/TextInput.kt
@@ -49,6 +49,7 @@ import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.CancelCircleFilled
 import io.channel.bezier.icon.View
 import io.channel.bezier.icon.ViewOff
+import io.channel.bezier.interaction.BezierComponentInteraction
 import io.channel.bezier.typography.BezierTypo
 
 private val HorizontalPadding = 10.dp
@@ -188,7 +189,10 @@ private fun SystemIcon(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null,
                             enabled = enabled,
-                            onClick = onClick,
+                            onClick = {
+                                BezierComponentInteraction.notify("TextInputV3", icon.imageVector.name)
+                                onClick()
+                            },
                     ),
             imageVector = icon.imageVector,
             contentDescription = null,

--- a/bezier/src/main/java/io/channel/bezier/v3/component/TextInput.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/TextInput.kt
@@ -190,7 +190,7 @@ private fun SystemIcon(
                             indication = null,
                             enabled = enabled,
                             onClick = {
-                                BezierComponentInteraction.notify("TextInputV3", icon.imageVector.name)
+                                BezierComponentInteraction.notify("TextInput", "V3", icon.imageVector.name)
                                 onClick()
                             },
                     ),


### PR DESCRIPTION
## 무엇

컴포넌트 인터랙션 관찰 지점 추가 — 앱(호스트)이 리스너 하나를 설정하면 bezier 컴포넌트가 소유한 클릭/토글을 컴포넌트 이름·버전·라벨과 함께 통지받는다.

- `interaction/BezierComponentInteraction`: `onComponentClick: ((component: String, version: String?, label: String?) -> Unit)?` 단일 훅. 기본 `null`(no-op) — 설정하지 않으면 동작·성능 변화 없음. 리스너 예외는 격리되어 컴포넌트 동작에 영향을 주지 않는다.
- component 는 버전 무관 이름("Button", "Switch" …), version 은 "V1"/"V3" 로 분리 — 같은 화면이 v1→v3 로 마이그레이션돼도 component 축은 안정적으로 유지되고 버전 변화만 version 으로 드러난다.
- `bezierComponent` 시맨틱스 마커: 클릭이 호출부에 있는 컴포넌트(ListItemContainer, SectionLabel, BaseItem)는 종류만 표시. IconActionListItem 은 ListItemContainer 조립품이라 별도 마커 없이 내부 마커를 그대로 노출한다.
- v3 Switch 에 `contentDescription: String? = null` 추가 — semantics 에 실반영(TalkBack)되는 접근성 필드이며, 지정 시 통지 라벨로도 전달된다. v3 인터랙티브 컴포넌트 중 유일하게 의미 값이 없던 컴포넌트(Button/Checkbox/BaseItem 은 라벨 필수, 아이콘류는 아이콘 이름).

## 적용 범위

- v3: Button, IconButton(아이콘 이름), Switch, Checkbox, Banner, FloatingBanner, Tag, TextInput, CollapsibleSection(헤더 접기/펴기), DropdownMenuItem, Search(클리어·취소)
- v1: Button, Switch, Checkbox, Banner, Tag, TextField, OutlineItem
- ChannelDialog/ConfirmModal 은 내부 Button 훅이 커버하므로 별도 훅 없음(중복 통지 방지)

## 왜

데스크 앱 DA 자동 트래킹(ElementClick)에서 컴포넌트 내부 clickable 은 앱 쪽 치환으로 잡을 수 없어, 라이브러리가 클릭을 소유한 지점에서 직접 통지한다. 이름/버전→이벤트 스키마 매핑은 앱 책임이라 라이브러리는 계측 스키마를 모른다.

## 검증

- `:bezier:compileDebugKotlin` 그린
- 공개 API 는 v3 Switch 의 옵셔널 파라미터 1개 추가 외 무변경(훅은 정적 옵셔널)
- sample 데모 하네스로 에뮬레이터 실측: 마커 병합 상승·라벨 인스턴스 정체성 보존·notify 경로 동작 확인
