### PR TITLE
[MOB-6796] v3 Button / Toast Figma 스펙 변경 반영

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/component/BezierText.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/BezierText.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.takeOrElse
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.extension.ifTrue
 import io.channel.bezier.typography.BezierTypo
@@ -27,9 +29,11 @@ fun BezierText(
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,
     minLines: Int = 1,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
 ) {
     val resolvedWeight = typo.fixedWeight ?: when (weight) {
         BezierWeight.Regular -> FontWeight.Normal
+        BezierWeight.Medium -> FontWeight.Medium
         BezierWeight.Bold -> FontWeight.Bold
     }
 
@@ -39,7 +43,7 @@ fun BezierText(
         style = TextStyle(
             fontSize = typo.fontSize,
             lineHeight = typo.lineHeight,
-            letterSpacing = typo.letterSpacing,
+            letterSpacing = letterSpacing.takeOrElse { typo.letterSpacing },
             fontWeight = resolvedWeight,
             fontFamily = typo.isMonospace.ifTrue(FontFamily.Monospace, null),
             color = color,

--- a/bezier/src/main/java/io/channel/bezier/typography/BezierTypography.kt
+++ b/bezier/src/main/java/io/channel/bezier/typography/BezierTypography.kt
@@ -8,6 +8,7 @@ import io.channel.bezier.dimension.BezierLineHeight
 
 enum class BezierWeight {
     Regular,
+    Medium,
     Bold,
 }
 

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Button.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -36,6 +37,7 @@ import io.channel.bezier.BezierIcon
 import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
+import io.channel.bezier.dimension.BezierLetterSpacing
 import io.channel.bezier.icon.Plus
 import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
@@ -48,7 +50,6 @@ fun Button(
         size: ButtonSize = ButtonSize.Medium,
         variant: ButtonVariant = ButtonVariant.Filled,
         semantic: ButtonSemantic = ButtonSemantic.Primary,
-        isActive: Boolean = false,
         isLoading: Boolean = false,
         enabled: Boolean = true,
         leadingContent: BezierIcon? = null,
@@ -59,8 +60,11 @@ fun Button(
     val spec = size.spec
     val colorSpec = buttonColorSpec(variant, semantic)
     val isPressed by interactionSource.collectIsPressedAsState()
-    val showOverlay = (isPressed || isActive) && variant != ButtonVariant.Filled
+    val showOverlay = isPressed && variant != ButtonVariant.Filled
     val containerAlpha = if (enabled) 1f else 0.4f
+    val backgroundColor = colorSpec.background?.let { background ->
+        if (isLoading) background.copy(alpha = background.alpha * 0.4f) else background
+    }
 
     Box(
             modifier = modifier
@@ -69,7 +73,7 @@ fun Button(
                     .graphicsLayer(alpha = containerAlpha)
                     .clip(CircleShape)
                     .then(
-                            if (colorSpec.background != null) Modifier.background(colorSpec.background)
+                            if (backgroundColor != null) Modifier.background(backgroundColor)
                             else Modifier,
                     )
                     .then(
@@ -98,7 +102,7 @@ fun Button(
                 Icon(
                         modifier = Modifier.size(ButtonIconLength),
                         imageVector = leadingContent.imageVector,
-                        tint = colorSpec.iconColor,
+                        tint = colorSpec.textColor,
                         contentDescription = null,
                 )
             }
@@ -108,15 +112,16 @@ fun Button(
                 BezierText(
                         text = text,
                         typo = size.typo,
-                        weight = BezierWeight.Bold,
+                        weight = size.weight,
                         color = colorSpec.textColor,
+                        letterSpacing = BezierLetterSpacing.Normal,
                 )
             }
             if (trailingContent != null) {
                 Icon(
                         modifier = Modifier.size(ButtonIconLength),
                         imageVector = trailingContent.imageVector,
-                        tint = colorSpec.iconColor,
+                        tint = colorSpec.textColor,
                         contentDescription = null,
                 )
             }
@@ -124,11 +129,7 @@ fun Button(
         if (isLoading) {
             Spinner(
                     size = size.spinnerSize,
-                    color = if (variant == ButtonVariant.Filled) {
-                        BezierTheme.colorsV3.fillBright
-                    } else {
-                        colorSpec.textColor
-                    },
+                    color = colorSpec.textColor,
             )
         }
     }
@@ -195,6 +196,12 @@ enum class ButtonSize {
             Xlarge -> BezierTypo.TextXLarge
         }
 
+    internal val weight: BezierWeight
+        get() = when (this) {
+            Xsmall, Small, Medium -> BezierWeight.Bold
+            Large, Xlarge -> BezierWeight.Medium
+        }
+
     internal val spinnerSize: SpinnerSize
         get() = when (this) {
             Xsmall -> SpinnerSize.Size12
@@ -228,7 +235,6 @@ internal data class ButtonLayoutSpec(
 internal data class ButtonColorSpec(
         val background: Color?,
         val textColor: Color,
-        val iconColor: Color,
         val border: Color?,
 )
 
@@ -240,21 +246,18 @@ internal fun buttonColorSpec(variant: ButtonVariant, semantic: ButtonSemantic): 
             ButtonSemantic.Primary -> ButtonColorSpec(
                     background = colors.fillNeutralHeaviest,
                     textColor = colors.textInverse,
-                    iconColor = colors.iconInverseHeavier,
                     border = null,
             )
 
             ButtonSemantic.Secondary -> ButtonColorSpec(
                     background = colors.fillNeutral,
                     textColor = colors.textNeutral,
-                    iconColor = colors.iconNeutralHeavy,
                     border = null,
             )
 
             ButtonSemantic.Destructive -> ButtonColorSpec(
                     background = colors.fillAccentRedHeavier,
-                    textColor = colors.textInverse,
-                    iconColor = colors.iconInverseHeavier,
+                    textColor = colors.textAbsoluteWhite,
                     border = null,
             )
         }
@@ -263,21 +266,18 @@ internal fun buttonColorSpec(variant: ButtonVariant, semantic: ButtonSemantic): 
             ButtonSemantic.Primary -> ButtonColorSpec(
                     background = null,
                     textColor = colors.textNeutralHeaviest,
-                    iconColor = colors.iconNeutralHeavier,
                     border = colors.borderNeutral,
             )
 
             ButtonSemantic.Secondary -> ButtonColorSpec(
                     background = null,
                     textColor = colors.textNeutralLight,
-                    iconColor = colors.iconNeutral,
                     border = colors.borderNeutral,
             )
 
             ButtonSemantic.Destructive -> ButtonColorSpec(
                     background = null,
                     textColor = colors.textAccentRed,
-                    iconColor = colors.iconAccentRed,
                     border = colors.borderNeutral,
             )
         }
@@ -286,21 +286,18 @@ internal fun buttonColorSpec(variant: ButtonVariant, semantic: ButtonSemantic): 
             ButtonSemantic.Primary -> ButtonColorSpec(
                     background = null,
                     textColor = colors.textNeutralLight,
-                    iconColor = colors.iconNeutralHeavy,
                     border = null,
             )
 
             ButtonSemantic.Secondary -> ButtonColorSpec(
                     background = null,
                     textColor = colors.textNeutralLighter,
-                    iconColor = colors.iconNeutral,
                     border = null,
             )
 
             ButtonSemantic.Destructive -> ButtonColorSpec(
                     background = null,
                     textColor = colors.textAccentRed,
-                    iconColor = colors.iconAccentRed,
                     border = null,
             )
         }
@@ -321,7 +318,7 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
     val labelColWidth = 88.dp
     val cellWidth = 132.dp
 
-    BezierTheme {
+    BezierTheme(isDark = isSystemInDarkTheme()) {
         Column(
                 modifier = Modifier
                         .background(BezierTheme.colorsV3.surface)
@@ -330,7 +327,7 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(modifier = Modifier.width(labelColWidth * 3))
-                listOf("default", "pressed", "active", "disabled", "loading").forEach { stateLabel ->
+                listOf("default", "pressed", "disabled", "loading").forEach { stateLabel ->
                     Box(
                             modifier = Modifier.width(cellWidth),
                             contentAlignment = Alignment.Center,
@@ -403,18 +400,6 @@ private fun ButtonMatrix(size: ButtonSize, sizeLabel: String) {
                                     leadingContent = BezierIcons.Plus,
                                     trailingContent = BezierIcons.Plus,
                                     interactionSource = pressedInteractionSource(),
-                            )
-                        }
-                        ButtonStateCell(cellWidth) {
-                            Button(
-                                    text = "Label",
-                                    onClick = {},
-                                    size = size,
-                                    variant = variant,
-                                    semantic = semantic,
-                                    leadingContent = BezierIcons.Plus,
-                                    trailingContent = BezierIcons.Plus,
-                                    isActive = true,
                             )
                         }
                         ButtonStateCell(cellWidth) {

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Toast.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Toast.kt
@@ -2,6 +2,7 @@ package io.channel.bezier.v3.component
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,12 +10,13 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -22,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierIcon
 import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
+import io.channel.bezier.color.DarkColor
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.CheckCircleFilled
 import io.channel.bezier.icon.ErrorDiamondFilled
@@ -34,42 +37,51 @@ fun Toast(
         modifier: Modifier = Modifier,
         preset: ToastPreset = ToastPreset.Info,
 ) {
-    val colors = BezierTheme.colorsV3
-    val iconSource = preset.iconSource
+    val isAmbientDark = BezierTheme.colorsV3 is DarkColor
 
-    Row(
-            modifier = modifier
-                    .widthIn(max = ToastMaxWidth)
-                    .heightIn(min = ToastMinHeight)
-                    .clip(CircleShape)
-                    .background(colors.fillGreyHeavier)
-                    .padding(horizontal = preset.horizontalPadding, vertical = ToastVerticalPadding),
-            horizontalArrangement = Arrangement.spacedBy(ToastIconTextGap),
-            verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (iconSource != null) {
-            Icon(
-                    modifier = Modifier.size(ToastIconLength),
-                    imageVector = iconSource.imageVector,
-                    tint = colors.iconNeutralHeavy,
-                    contentDescription = null,
+    BezierTheme(isDark = !isAmbientDark) {
+        val colors = BezierTheme.colorsV3
+        val iconSource = preset.iconSource
+        val iconColor = preset.iconColor()
+
+        Row(
+                modifier = modifier
+                        .widthIn(max = ToastMaxWidth)
+                        .heightIn(min = ToastMinHeight)
+                        .clip(RoundedCornerShape(ToastCornerRadius))
+                        .background(colors.surfaceGlass)
+                        .padding(horizontal = preset.horizontalPadding, vertical = ToastVerticalPadding),
+                horizontalArrangement = Arrangement.spacedBy(ToastIconTextGap),
+                verticalAlignment = Alignment.Top,
+        ) {
+            if (iconSource != null && iconColor != null) {
+                Icon(
+                        modifier = Modifier.size(ToastIconLength),
+                        imageVector = iconSource.imageVector,
+                        tint = iconColor,
+                        contentDescription = null,
+                )
+            }
+            BezierText(
+                    modifier = Modifier
+                            .weight(1f, fill = false)
+                            .padding(vertical = ToastTextVerticalPadding),
+                    text = text,
+                    typo = BezierTypo.TextMedium,
+                    weight = BezierWeight.Bold,
+                    color = colors.textNeutral,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = ToastMaxLines,
             )
         }
-        BezierText(
-                modifier = Modifier.weight(1f, fill = false),
-                text = text,
-                typo = BezierTypo.TextMedium,
-                weight = BezierWeight.Bold,
-                color = colors.textNeutral,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = ToastMaxLines,
-        )
     }
 }
 
 private val ToastMaxWidth: Dp = 460.dp
 private val ToastMinHeight: Dp = 40.dp
-private val ToastVerticalPadding: Dp = 10.dp
+private val ToastCornerRadius: Dp = 20.dp
+private val ToastVerticalPadding: Dp = 12.dp
+private val ToastTextVerticalPadding: Dp = 1.dp
 private val ToastIconTextGap: Dp = 6.dp
 private val ToastIconLength: Dp = 20.dp
 private const val ToastMaxLines: Int = 2
@@ -91,11 +103,18 @@ enum class ToastPreset {
             Info -> 14.dp
             Success, Error -> 12.dp
         }
+
+    @Composable
+    internal fun iconColor(): Color? = when (this) {
+        Info -> null
+        Success -> BezierTheme.colorsV3.iconAccentGreen
+        Error -> BezierTheme.colorsV3.iconAccentRed
+    }
 }
 
 @Composable
 private fun ToastMatrix() {
-    BezierTheme {
+    BezierTheme(isDark = isSystemInDarkTheme()) {
         Column(
                 modifier = Modifier
                         .background(BezierTheme.colorsV3.surface)

--- a/bezier/src/main/java/io/channel/bezier/v3/component/Toast.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Toast.kt
@@ -1,8 +1,6 @@
 package io.channel.bezier.v3.component
 
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,7 +22,6 @@ import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierIcon
 import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
-import io.channel.bezier.color.DarkColor
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.CheckCircleFilled
 import io.channel.bezier.icon.ErrorDiamondFilled
@@ -37,9 +34,7 @@ fun Toast(
         modifier: Modifier = Modifier,
         preset: ToastPreset = ToastPreset.Info,
 ) {
-    val isAmbientDark = BezierTheme.colorsV3 is DarkColor
-
-    BezierTheme(isDark = !isAmbientDark) {
+    BezierTheme(isDark = !BezierTheme.isDark) {
         val colors = BezierTheme.colorsV3
         val iconSource = preset.iconSource
         val iconColor = preset.iconColor()
@@ -113,8 +108,10 @@ enum class ToastPreset {
 }
 
 @Composable
-private fun ToastMatrix() {
-    BezierTheme(isDark = isSystemInDarkTheme()) {
+private fun ToastMatrix(isDark: Boolean) {
+    BezierTheme.isDark = isDark
+
+    BezierTheme {
         Column(
                 modifier = Modifier
                         .background(BezierTheme.colorsV3.surface)
@@ -134,8 +131,8 @@ private fun ToastMatrix() {
 
 @Preview(showBackground = true, widthDp = 520)
 @Composable
-private fun ToastMatrixLightPreview() = ToastMatrix()
+private fun ToastMatrixLightPreview() = ToastMatrix(isDark = false)
 
-@Preview(showBackground = true, widthDp = 520, uiMode = UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, widthDp = 520)
 @Composable
-private fun ToastMatrixDarkPreview() = ToastMatrix()
+private fun ToastMatrixDarkPreview() = ToastMatrix(isDark = true)

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -1,11 +1,11 @@
 package io.channel.bezier.compose.sample
 
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -69,6 +69,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
+        // Toast 처럼 전역 BezierTheme.isDark 를 읽는 컴포넌트가 있어 시스템 테마를 전역에 반영한다.
+        BezierTheme.isDark = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+                Configuration.UI_MODE_NIGHT_YES
+
         setContent {
             PlaygroundApp()
         }
@@ -77,7 +82,7 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun PlaygroundApp() {
-    BezierTheme(isDark = isSystemInDarkTheme()) {
+    BezierTheme {
         Box(
                 modifier = Modifier
                         .fillMaxSize()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -76,7 +77,7 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun PlaygroundApp() {
-    BezierTheme {
+    BezierTheme(isDark = isSystemInDarkTheme()) {
         Box(
                 modifier = Modifier
                         .fillMaxSize()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ButtonPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ButtonPlaygroundScreen.kt
@@ -37,7 +37,6 @@ fun ButtonPlaygroundScreen(onBack: () -> Unit) {
     var size by remember { mutableStateOf(ButtonSize.Medium) }
     var variant by remember { mutableStateOf(ButtonVariant.Filled) }
     var semantic by remember { mutableStateOf(ButtonSemantic.Primary) }
-    var isActive by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
     var enabled by remember { mutableStateOf(true) }
     var showLeadingIcon by remember { mutableStateOf(true) }
@@ -78,7 +77,6 @@ fun ButtonPlaygroundScreen(onBack: () -> Unit) {
                         size = size,
                         variant = variant,
                         semantic = semantic,
-                        isActive = isActive,
                         isLoading = isLoading,
                         enabled = enabled,
                         leadingContent = if (showLeadingIcon) BezierIcons.Plus else null,
@@ -91,7 +89,6 @@ fun ButtonPlaygroundScreen(onBack: () -> Unit) {
             EnumControl("Size", ButtonSize.values(), size) { size = it }
             EnumControl("Variant", ButtonVariant.values(), variant) { variant = it }
             EnumControl("Semantic", ButtonSemantic.values(), semantic) { semantic = it }
-            BooleanControl("isActive", isActive) { isActive = it }
             BooleanControl("isLoading", isLoading) { isLoading = it }
             BooleanControl("enabled", enabled) { enabled = it }
             BooleanControl("leadingIcon", showLeadingIcon) { showLeadingIcon = it }


### PR DESCRIPTION
## 개요

Figma [🚧 Mobile Components](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY) 실측 기준으로 v3 `Button` / `Toast`의 스펙 불일치를 동기화합니다.

- Button: [1734:146](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1734-146&m=dev) · Toast: [2090:17](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2090-17&m=dev)
- 참고 spec 문서: BezierSwift [BezierButton/SPEC.md](https://github.com/channel-io/BezierSwift/blob/main/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md) / [BezierToast/SPEC.md](https://github.com/channel-io/BezierSwift/blob/main/Sources/BezierSwift/MasterComponent/BezierToast/SPEC.md) — 일부 값이 최신 Figma와 달라 **Figma 실측을 우선**했습니다 (아래 "spec 문서와 다른 부분" 참조)

## 변경사항

### Button
| 항목 | 변경 |
|---|---|
| filled × destructive 텍스트/스피너 | `textInverse` → `textAbsoluteWhite` (`color/text/absolute/white`, 다크 테마에서도 흰색 유지) |
| 아이콘/스피너 색 | 라벨 텍스트 색으로 통일 — Figma에 아이콘 색 바인딩이 없고 iOS와 동일 합의. 스피너의 `fillBright` 분기 제거 |
| large/xlarge 타이포 | weight **Medium(500)** (`label/weight` 변수), letter-spacing 0 명시 (`label/letter-spacing`) |
| loading | **배경 레이어만 0.4배 흐림** (Figma: background 레이어에 `opacity/disabled` 바인딩. 스피너·보더는 원래 불투명도, outlined/ghost는 배경 없음) |
| `isActive` 제거 | ⚠️ breaking — active state는 런타임 API 미노출 합의 (iOS BezierButton 동일) |

### Toast
| 항목 | 변경 |
|---|---|
| 표면 반전 | ambient `colorsV3` 기준 반대 테마 팔레트 적용 (라이트 앱 → 다크 글래스, 다크 앱 → 라이트 글래스) |
| 배경 | `fillGreyHeavier`(불투명) → **`surfaceGlass`**(알파 90%). Figma의 backdrop blur 60은 Compose 표준 API 제약으로 보류 |
| 형태 | radius pill → **고정 20dp** (`radius/20`), 세로 패딩 10 → **12** (1줄 높이 44) |
| 아이콘 | success `iconAccentGreen` / error `iconAccentRed` (기존 무채색 `iconNeutralHeavy`) |
| 정렬 | 아이콘-텍스트 상단 정렬 + 텍스트 상하 1dp 보정 (Figma `py-px`) — 2줄 시 아이콘이 첫 줄에 고정 |

### 공용
- `BezierWeight`에 `Medium` 추가 (Regular/Medium/Bold)
- `BezierText`에 `letterSpacing: TextUnit = TextUnit.Unspecified` override 추가 (파라미터 맨 끝)
- sample: 시스템 다크모드 연동 (`BezierTheme(isDark = isSystemInDarkTheme())`), Button 플레이그라운드 `isActive` 컨트롤 제거

## 스크린샷

### Button
| | Light | Dark |
|---|---|---|
| medium filled primary | <img width="360" src="https://github.com/user-attachments/assets/0985b58f-c5a0-4d82-ad8f-a1212b68839d"> | <img width="360" src="https://github.com/user-attachments/assets/57690182-e8ff-451a-9ebf-7793064e2c79"> |
| xlarge (Medium weight) | <img width="360" src="https://github.com/user-attachments/assets/240be0b3-5d96-4b1e-82a5-895b75e161b8"> | |
| destructive loading (배경 흐림 + 원색 스피너) | <img width="360" src="https://github.com/user-attachments/assets/acca0fdc-781d-441d-8682-6e9c2cf3361e"> | <img width="360" src="https://github.com/user-attachments/assets/d72cf3ec-1b49-490a-a8b2-2e06622ab061"> |

### Toast
| | Light | Dark |
|---|---|---|
| info (반전 글래스 표면) | <img width="360" src="https://github.com/user-attachments/assets/b8ce1ded-0945-45f2-ad47-c7b37c633197"> | <img width="360" src="https://github.com/user-attachments/assets/f61e15ed-5439-48c3-8fbd-4a08c5689163"> |
| success (accent 아이콘) | <img width="360" src="https://github.com/user-attachments/assets/199f32ff-c8c3-4c4d-92c0-bfa63f012b01"> | |
| error 2줄 말줄임 + 상단 정렬 | <img width="360" src="https://github.com/user-attachments/assets/b3214746-b2da-4433-90a0-ea23f50dcd72"> | <img width="360" src="https://github.com/user-attachments/assets/358cb7cc-1304-415e-b50a-d70b20f2b408"> |

## spec 문서와 다른 부분 (Figma 실측 우선)

BezierSwift spec 문서가 최신 Figma보다 뒤처져 있어 실측값을 채택했습니다. 업스트림 문서 정정이 필요합니다:
- Button §4: "Custom/SemiBold(600), small 14/18, large·xlarge 16/20" → 실측은 전 size 토큰 바인딩, 700/700/700/**500**/**500**, small 14/**20**, large·xlarge 16/**24**
- Button §6: "pressed = opacity 낮춤" → 실측은 `-hovered` 배경 토큰 처리 (해당 토큰이 Android 토큰 싱크에 미수신이라 filled pressed 배경 교체는 **후속 작업**, 비-filled의 5% 오버레이는 실측과 일치)
- Toast §2/§3: radius pill→20, 패딩 10→12, 배경 fillGreyHeavier→surfaceGlass, 아이콘 무채색→accent

## 검증

- figma-component-spec 파이프라인: Phase 2 (Figma ↔ spec, 검증자 10개) → Phase 3 (spec ↔ 구현) ✅
- `/code-review` 15건 중 6건 반영 (Toast 반전 ambient화, BezierText 시그니처/센티널, letterSpacing 토큰화, Info 죽은 분기, 다크 프리뷰, sample 전역 쓰기 제거). `BezierWeight` ordinal 이동(Medium 삽입)은 의미 순서 우선 — ordinal 직렬화 소비자 확인 필요
- `:bezier` / `:sample` assembleDebug ✅ · 에뮬레이터 라이트/다크 시각 확인 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - `BezierText`에서 문자 간격을 직접 지정할 수 있습니다.
  - 타이포그래피에 `Medium` 글꼴 굵기가 추가되었습니다.

- **개선 사항**
  - 버튼의 눌림·로딩 상태 표시, 색상, 텍스트 굵기와 자간이 개선되었습니다.
  - 토스트가 시스템 테마를 반영하며, 글래스 스타일과 프리셋별 아이콘 색상을 적용합니다.
  - 샘플 앱이 시스템 다크 테마 설정을 자동으로 반영합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->