### PR TITLE
v3 Search 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Search.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Search.kt
@@ -1,0 +1,246 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.CancelCircleFilled
+import io.channel.bezier.icon.Search
+import io.channel.bezier.typography.BezierTypo
+
+private val Height = 40.dp
+private val MinWidth = 40.dp
+private val FieldGap = 8.dp
+private val ItemGap = 6.dp
+private val HorizontalPadding = 10.dp
+private val CornerRadius = 12.dp
+private val BorderWidth = 1.5.dp
+private val IconSize = 20.dp
+private val CancelHorizontalPadding = 4.dp
+private const val DisabledAlpha = 0.4f
+
+private val FieldShape = RoundedCornerShape(CornerRadius)
+
+@Composable
+fun Search(
+        value: String,
+        onValueChange: (String) -> Unit,
+        modifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        placeholder: String? = null,
+        allowClear: Boolean = true,
+        cancelText: String? = null,
+        onCancelClick: () -> Unit = {},
+        keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+        keyboardActions: KeyboardActions = KeyboardActions.Default,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val colors = BezierTheme.colorsV3
+    val focused by interactionSource.collectIsFocusedAsState()
+
+    val active = enabled && focused
+    val fillColor = if (active) colors.fillGreyLight else colors.fillGrey
+    val borderColor = if (active) colors.stateActive else colors.stateDefault
+
+    val textStyle = remember(colors.textNeutral) {
+        TextStyle(
+                color = colors.textNeutral,
+                fontSize = BezierTypo.TextXLarge.fontSize,
+                lineHeight = BezierTypo.TextXLarge.lineHeight,
+                letterSpacing = BezierTypo.TextXLarge.letterSpacing,
+                fontWeight = FontWeight.Normal,
+        )
+    }
+
+    Row(
+            modifier = modifier
+                    .height(Height)
+                    .widthIn(min = MinWidth)
+                    .graphicsLayer { alpha = if (enabled) 1f else DisabledAlpha }
+                    .clip(RectangleShape),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(FieldGap),
+    ) {
+        BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .clip(FieldShape)
+                        .background(fillColor)
+                        .border(BorderWidth, borderColor, FieldShape)
+                        .padding(horizontal = HorizontalPadding),
+                enabled = enabled,
+                textStyle = textStyle,
+                singleLine = true,
+                keyboardOptions = keyboardOptions,
+                keyboardActions = keyboardActions,
+                interactionSource = interactionSource,
+                cursorBrush = SolidColor(colors.textNeutral),
+                decorationBox = { innerTextField ->
+                    Row(
+                            modifier = Modifier.fillMaxSize(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(ItemGap),
+                    ) {
+                        Icon(
+                                modifier = Modifier.size(IconSize),
+                                imageVector = BezierIcons.Search.imageVector,
+                                contentDescription = null,
+                                tint = colors.iconNeutral,
+                        )
+
+                        Box(modifier = Modifier.weight(1f)) {
+                            innerTextField()
+
+                            if (value.isEmpty() && placeholder != null) {
+                                BezierText(
+                                        text = placeholder,
+                                        typo = BezierTypo.TextXLarge,
+                                        color = colors.textNeutralLighter,
+                                        overflow = TextOverflow.Ellipsis,
+                                        maxLines = 1,
+                                )
+                            }
+                        }
+
+                        if (allowClear && value.isNotEmpty() && enabled) {
+                            Icon(
+                                    modifier = Modifier
+                                            .size(IconSize)
+                                            .clickable(
+                                                    interactionSource = remember { MutableInteractionSource() },
+                                                    indication = null,
+                                                    onClick = { onValueChange("") },
+                                            ),
+                                    imageVector = BezierIcons.CancelCircleFilled.imageVector,
+                                    contentDescription = null,
+                                    tint = colors.iconNeutral,
+                            )
+                        }
+                    }
+                },
+        )
+
+        if (cancelText != null) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxHeight()
+                            .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null,
+                                    enabled = enabled,
+                                    onClick = onCancelClick,
+                            )
+                            .padding(horizontal = CancelHorizontalPadding),
+                    contentAlignment = Alignment.Center,
+            ) {
+                BezierText(
+                        text = cancelText,
+                        typo = BezierTypo.TextMedium,
+                        color = colors.textNeutral,
+                        maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchMatrix() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .background(BezierTheme.colorsV3.surface)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Text(
+                    text = "hasValue = false",
+                    color = BezierTheme.colorsV3.textNeutral,
+            )
+            Search(
+                    value = "",
+                    onValueChange = {},
+                    placeholder = "Search by name, email, phone",
+                    modifier = Modifier.fillMaxWidth(),
+            )
+            Search(
+                    value = "",
+                    onValueChange = {},
+                    placeholder = "Search by name, email, phone",
+                    enabled = false,
+                    modifier = Modifier.fillMaxWidth(),
+            )
+
+            Text(
+                    text = "hasValue = true",
+                    color = BezierTheme.colorsV3.textNeutral,
+            )
+            Search(
+                    value = "John Doe",
+                    onValueChange = {},
+                    modifier = Modifier.fillMaxWidth(),
+            )
+            Search(
+                    value = "John Doe",
+                    onValueChange = {},
+                    enabled = false,
+                    modifier = Modifier.fillMaxWidth(),
+            )
+
+            Text(
+                    text = "cancelButton = true",
+                    color = BezierTheme.colorsV3.textNeutral,
+            )
+            Search(
+                    value = "John Doe",
+                    onValueChange = {},
+                    cancelText = "Cancel",
+                    modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Preview(showBackground = true, widthDp = 360, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun SearchMatrixPreview() = SearchMatrix()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -49,6 +49,8 @@ import io.channel.bezier.compose.sample.playground.ConfirmModalPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ConfirmModalPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ModalPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ModalPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.SearchPlaygroundKey
+import io.channel.bezier.compose.sample.playground.SearchPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SectionPlaygroundKey
@@ -113,6 +115,7 @@ private fun PlaygroundApp() {
                                     onSelectTextArea = { backStack.add(TextAreaPlaygroundKey) },
                                     onSelectModal = { backStack.add(ModalPlaygroundKey) },
                                     onSelectConfirmModal = { backStack.add(ConfirmModalPlaygroundKey) },
+                                    onSelectSearch = { backStack.add(SearchPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -183,6 +186,9 @@ private fun PlaygroundApp() {
                         }
                         entry<ConfirmModalPlaygroundKey> {
                             ConfirmModalPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<SearchPlaygroundKey> {
+                            SearchPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -40,6 +40,7 @@ fun ComponentListScreen(
         onSelectTextArea: () -> Unit,
         onSelectModal: () -> Unit,
         onSelectConfirmModal: () -> Unit,
+        onSelectSearch: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -99,6 +100,8 @@ fun ComponentListScreen(
             ComponentRow("Modal", onClick = onSelectModal)
             Divider()
             ComponentRow("ConfirmModal", onClick = onSelectConfirmModal)
+            Divider()
+            ComponentRow("Search", onClick = onSelectSearch)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -24,3 +24,4 @@ data object ItemsPlaygroundKey
 data object TextAreaPlaygroundKey
 data object ModalPlaygroundKey
 data object ConfirmModalPlaygroundKey
+data object SearchPlaygroundKey

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/SearchPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/SearchPlaygroundScreen.kt
@@ -1,0 +1,84 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.Search
+
+@Composable
+fun SearchPlaygroundScreen(onBack: () -> Unit) {
+    var value by remember { mutableStateOf("") }
+    var enabled by remember { mutableStateOf(true) }
+    var allowClear by remember { mutableStateOf(true) }
+    var cancelButton by remember { mutableStateOf(false) }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Search") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
+        ) {
+            Box(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BezierTheme.colorsV3.surfaceLow)
+                            .padding(32.dp),
+            ) {
+                Search(
+                        value = value,
+                        onValueChange = { value = it },
+                        enabled = enabled,
+                        placeholder = "Search by name, email, phone",
+                        allowClear = allowClear,
+                        cancelText = if (cancelButton) "Cancel" else null,
+                        onCancelClick = { value = "" },
+                        modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            Divider()
+
+            BooleanControl("enabled", enabled) { enabled = it }
+            BooleanControl("allowClear", allowClear) { allowClear = it }
+            BooleanControl("cancelButton", cancelButton) { cancelButton = it }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

Figma Search 컴포넌트(node `2365:314`)를 v3 패키지에 구현합니다. SearchIcon이 고정된 단일 행 검색 입력 필드로, 검색 외 일반 텍스트 입력은 기존 `TextInput`을 씁니다.

## 변경 사항

### API

```kotlin
@Composable
fun Search(
        value: String,
        onValueChange: (String) -> Unit,
        modifier: Modifier = Modifier,
        enabled: Boolean = true,
        placeholder: String? = null,
        allowClear: Boolean = true,
        cancelText: String? = null,
        onCancelClick: () -> Unit = {},
        keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
        keyboardActions: KeyboardActions = KeyboardActions.Default,
        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
)
```

### Figma property 매핑

| Figma property | Compose | 근거 |
|---|---|---|
| `state` (default / focused / disabled) | `enabled` + `interactionSource.collectIsFocusedAsState()` | state enum을 두지 않고 파생시키는 `TextInput` 컨벤션 |
| `hasValue` | `value.isEmpty()` 파생 | 동일 |
| `allowClear` (기본 true) | `allowClear: Boolean = true` | — |
| `cancelButton` (기본 false) | `cancelText: String? = null` + `onCancelClick` | 텍스트 null 여부로 렌더를 판정하는 `ConfirmModal` 선례 |
| `placeholder` | `placeholder: String? = null` | — |
| `value` | `value` / `onValueChange` | — |

### 컬러 — v3 토큰만

| 대상 | default · disabled | focused |
|---|---|---|
| background | `fillGrey` | `fillGreyLight` |
| border (1.5dp) | `stateDefault` | `stateActive` |

| 위치 | 토큰 |
|---|---|
| placeholder | `textNeutralLighter` |
| value · cancel 라벨 | `textNeutral` |
| SearchIcon · clear 아이콘 | `iconNeutral` |

`disabled`는 루트 alpha 0.4를 적용하고 하위 색 토큰은 `default`와 동일합니다. 포커스 상태에서 `enabled`가 false로 뒤집혀도 disabled 색이 보장되도록 `enabled && focused`로 게이팅했습니다.

### 레이아웃

| 요소 | 값 |
|---|---|
| 루트 height / min-width | 40 / 40 |
| 루트 gap (필드 ↔ Cancel) | 8 |
| SearchField gap / horizontal padding | 6 / 10 |
| corner radius | 12 |
| border width | 1.5 |
| SearchIcon · clear 아이콘 | 20 × 20 |
| cancelButton horizontal padding | 4 |

### 아이콘

`BezierIcons.Search`(Regular)를 씁니다. `SearchBold`는 Figma 벡터 대비 stroke가 1.5배라 불일치합니다 — 정규화 비교 시 외곽원 반지름 0.40 / 내곽 0.30 / stroke 0.10이 Figma와 정확히 일치하는 쪽이 Regular입니다.

### 샘플

`Search` 플레이그라운드를 추가했습니다 (`enabled` / `allowClear` / `cancelButton` 토글).

## 검증

`figma-component-spec` 스킬로 spec 검증 7개 + 구현 검증 1개를 돌려 전부 통과했습니다. 검증 중 잡아 고친 것:

- **cancelButton 라벨 타이포 오분류** — custom typography가 아니라 `Typography/text/medium` 토큰 → `BezierTypo.TextMedium`
- **disabled 색 미보장** — 위 `enabled && focused` 게이팅으로 차단
- **루트 clip 누락** — Figma `overflow-clip` 대응 `clip(RectangleShape)` 추가

`ts -f ./gradlew :sample:compileDebugKotlin` BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 검색어 입력, 플레이스홀더, 활성화·지우기·취소 버튼을 지원하는 검색 컴포넌트를 추가했습니다.
  * 포커스와 활성화 상태에 따라 검색 UI가 변경됩니다.
  * 검색 컴포넌트의 라이트·다크 테마 미리보기를 제공합니다.
  * 샘플 앱에 검색 플레이그라운드 화면과 설정 옵션을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->