### PR TITLE
[MOB-6611] v3 CollapsibleSection 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/CollapsibleSection.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/CollapsibleSection.kt
@@ -2,6 +2,7 @@ package io.channel.bezier.v3.component
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,10 +13,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,6 +32,7 @@ import io.channel.bezier.BezierIcon
 import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.ChevronSmallDown
 import io.channel.bezier.icon.ChevronSmallRight
 import io.channel.bezier.icon.Folder
 import io.channel.bezier.icon.Plus
@@ -32,45 +40,40 @@ import io.channel.bezier.typography.BezierTypo
 import io.channel.bezier.typography.BezierWeight
 
 @Composable
-fun Section(
+fun CollapsibleSection(
+        label: String,
+        open: Boolean,
+        onOpenChange: ((Boolean) -> Unit)?,
         modifier: Modifier = Modifier,
-        label: String? = null,
         labelColor: SectionLabelColor = SectionLabelColor.NeutralDark,
         labelLeadingContent: (@Composable () -> Unit)? = null,
         labelTrailingContent: (@Composable () -> Unit)? = null,
-        variant: SectionVariant = SectionVariant.Solid,
         content: @Composable () -> Unit,
 ) {
     Column(
             modifier = modifier.fillMaxWidth(),
     ) {
-        if (label != null) {
-            SectionLabel(
-                    label = label,
-                    color = labelColor,
-                    leadingContent = labelLeadingContent,
-                    trailingContent = labelTrailingContent,
-            )
-        }
+        CollapsibleSectionLabel(
+                label = label,
+                color = labelColor,
+                open = open,
+                onOpenChange = onOpenChange,
+                leadingContent = labelLeadingContent,
+                trailingContent = labelTrailingContent,
+        )
 
-        when (variant) {
-            SectionVariant.Solid -> Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    content = { content() },
-            )
-
-            SectionVariant.Card -> Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    content = content,
-            )
+        if (open) {
+            content()
         }
     }
 }
 
 @Composable
-private fun SectionLabel(
+private fun CollapsibleSectionLabel(
         label: String,
         color: SectionLabelColor,
+        open: Boolean,
+        onOpenChange: ((Boolean) -> Unit)?,
         leadingContent: (@Composable () -> Unit)?,
         trailingContent: (@Composable () -> Unit)?,
         modifier: Modifier = Modifier,
@@ -78,18 +81,28 @@ private fun SectionLabel(
     Row(
             modifier = modifier
                     .fillMaxWidth()
-                    .heightIn(min = SectionLabelMinHeight)
-                    .padding(horizontal = SectionLabelHorizontalPadding),
-            horizontalArrangement = Arrangement.spacedBy(SectionLabelTrailingGap),
+                    .clip(CollapsibleSectionLabelShape)
+                    .then(
+                            if (onOpenChange != null) {
+                                Modifier.clickable { onOpenChange(!open) }
+                            } else {
+                                Modifier
+                            },
+                    )
+                    .heightIn(min = LabelMinHeight)
+                    .padding(horizontal = LabelHorizontalPadding),
+            horizontalArrangement = Arrangement.spacedBy(LabelTrailingGap),
             verticalAlignment = Alignment.CenterVertically,
     ) {
         Row(
-                modifier = Modifier.weight(1f),
-                horizontalArrangement = Arrangement.spacedBy(SectionLabelLeadingGap),
+                modifier = Modifier
+                        .weight(1f)
+                        .heightIn(min = CenterContentMinHeight),
+                horizontalArrangement = Arrangement.spacedBy(CenterContentGap),
                 verticalAlignment = Alignment.CenterVertically,
         ) {
             if (leadingContent != null) {
-                Box(modifier = Modifier.size(SectionLabelSlotSize)) {
+                Box(modifier = Modifier.size(LeadingContentSize)) {
                     leadingContent()
                 }
             }
@@ -101,14 +114,25 @@ private fun SectionLabel(
                     color = color.textColor(),
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f, fill = false),
+            )
+
+            Icon(
+                    modifier = Modifier.size(ChevronSize),
+                    imageVector = if (open) {
+                        BezierIcons.ChevronSmallDown.imageVector
+                    } else {
+                        BezierIcons.ChevronSmallRight.imageVector
+                    },
+                    tint = color.chevronColor(),
+                    contentDescription = null,
             )
         }
 
         if (trailingContent != null) {
             Box(
-                    modifier = Modifier.height(SectionLabelSlotSize),
-                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.height(TrailingContentHeight),
+                    contentAlignment = Alignment.CenterEnd,
             ) {
                 trailingContent()
             }
@@ -116,31 +140,28 @@ private fun SectionLabel(
     }
 }
 
-enum class SectionVariant {
-    Solid,
-    Card,
+@Composable
+private fun SectionLabelColor.chevronColor(): Color = when (this) {
+    SectionLabelColor.NeutralDark -> BezierTheme.colorsV3.iconNeutralHeavier
+    SectionLabelColor.NeutralLight -> BezierTheme.colorsV3.iconNeutral
 }
 
-enum class SectionLabelColor {
-    NeutralDark,
-    NeutralLight,
-}
+private val LabelMinHeight: Dp = 32.dp
+private val LabelHorizontalPadding: Dp = 10.dp
+private val LabelTrailingGap: Dp = 4.dp
+private val CenterContentGap: Dp = 8.dp
+private val CenterContentMinHeight: Dp = 24.dp
+private val LeadingContentSize: Dp = 20.dp
+private val ChevronSize: Dp = 16.dp
+private val TrailingContentHeight: Dp = 20.dp
+private val CollapsibleSectionLabelShape = RoundedCornerShape(8.dp)
 
 @Composable
-internal fun SectionLabelColor.textColor(): Color = when (this) {
-    SectionLabelColor.NeutralDark -> BezierTheme.colorsV3.textNeutral
-    SectionLabelColor.NeutralLight -> BezierTheme.colorsV3.textNeutralLighter
-}
-
-private val SectionLabelMinHeight: Dp = 32.dp
-private val SectionLabelHorizontalPadding: Dp = 10.dp
-private val SectionLabelLeadingGap: Dp = 8.dp
-private val SectionLabelTrailingGap: Dp = 4.dp
-private val SectionLabelSlotSize: Dp = 20.dp
-
-@Composable
-private fun SectionPreviewContent() {
+private fun CollapsibleSectionPreviewContent() {
     BezierTheme {
+        var firstOpen by remember { mutableStateOf(true) }
+        var secondOpen by remember { mutableStateOf(false) }
+
         Column(
                 modifier = Modifier
                         .background(BezierTheme.colorsV3.surfaceLow)
@@ -148,33 +169,33 @@ private fun SectionPreviewContent() {
                         .padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
-            Section(
+            CollapsibleSection(
                     label = "Section Label",
-                    labelLeadingContent = { SectionPreviewIcon(BezierIcons.Folder) },
-                    labelTrailingContent = { SectionPreviewIcon(BezierIcons.ChevronSmallRight) },
+                    open = firstOpen,
+                    onOpenChange = { firstOpen = it },
+                    labelLeadingContent = { CollapsibleSectionPreviewIcon(BezierIcons.Folder) },
             ) {
                 repeat(3) {
                     BaseItem(
+                            modifier = Modifier.fillMaxWidth(),
                             label = "Label",
-                            size = BaseItemSize.Small,
-                            leadingContent = { SectionPreviewIcon(BezierIcons.Plus) },
+                            size = BaseItemSize.Medium,
+                            leadingContent = { CollapsibleSectionPreviewIcon(BezierIcons.Plus) },
                     )
                 }
             }
 
-            Section(
+            CollapsibleSection(
                     label = "Overlay Label",
+                    open = secondOpen,
+                    onOpenChange = { secondOpen = it },
                     labelColor = SectionLabelColor.NeutralLight,
-                    variant = SectionVariant.Card,
             ) {
-                repeat(4) { index ->
-                    if (index > 0) {
-                        Divider(sideIndent = false, parallelIndent = false)
-                    }
+                repeat(2) {
                     BaseItem(
+                            modifier = Modifier.fillMaxWidth(),
                             label = "Label",
                             size = BaseItemSize.Medium,
-                            leadingContent = { SectionPreviewIcon(BezierIcons.Plus) },
                     )
                 }
             }
@@ -183,7 +204,7 @@ private fun SectionPreviewContent() {
 }
 
 @Composable
-private fun SectionPreviewIcon(icon: BezierIcon) {
+private fun CollapsibleSectionPreviewIcon(icon: BezierIcon) {
     Icon(
             modifier = Modifier.fillMaxSize(),
             imageVector = icon.imageVector,
@@ -194,8 +215,8 @@ private fun SectionPreviewIcon(icon: BezierIcon) {
 
 @Preview(showBackground = true, widthDp = 400)
 @Composable
-private fun SectionPreview() = SectionPreviewContent()
+private fun CollapsibleSectionPreview() = CollapsibleSectionPreviewContent()
 
 @Preview(showBackground = true, widthDp = 400, uiMode = UI_MODE_NIGHT_YES)
 @Composable
-private fun SectionDarkPreview() = SectionPreviewContent()
+private fun CollapsibleSectionDarkPreview() = CollapsibleSectionPreviewContent()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -51,6 +51,8 @@ import io.channel.bezier.compose.sample.playground.ModalPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ModalPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundKey
 import io.channel.bezier.compose.sample.playground.ProgressBarPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.CollapsibleSectionPlaygroundKey
+import io.channel.bezier.compose.sample.playground.CollapsibleSectionPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SectionPlaygroundKey
 import io.channel.bezier.compose.sample.playground.SectionPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.SpinnerPlaygroundKey
@@ -104,6 +106,7 @@ private fun PlaygroundApp() {
                                     onSelectToast = { backStack.add(ToastPlaygroundKey) },
                                     onSelectCard = { backStack.add(CardPlaygroundKey) },
                                     onSelectSection = { backStack.add(SectionPlaygroundKey) },
+                                    onSelectCollapsibleSection = { backStack.add(CollapsibleSectionPlaygroundKey) },
                                     onSelectTextInput = { backStack.add(TextInputPlaygroundKey) },
                                     onSelectBanner = { backStack.add(BannerPlaygroundKey) },
                                     onSelectBaseItem = { backStack.add(BaseItemPlaygroundKey) },
@@ -156,6 +159,9 @@ private fun PlaygroundApp() {
                         }
                         entry<SectionPlaygroundKey> {
                             SectionPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<CollapsibleSectionPlaygroundKey> {
+                            CollapsibleSectionPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                         entry<TextInputPlaygroundKey> {
                             TextInputPlaygroundScreen(onBack = { backStack.removeLastOrNull() })

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/CollapsibleSectionPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/CollapsibleSectionPlaygroundScreen.kt
@@ -1,0 +1,151 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.icon.Bookmark
+import io.channel.bezier.icon.Folder
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.icon.Star
+import io.channel.bezier.v3.component.BaseItem
+import io.channel.bezier.v3.component.BaseItemSize
+import io.channel.bezier.v3.component.CollapsibleSection
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+import io.channel.bezier.v3.component.SectionLabelColor
+
+@Composable
+fun CollapsibleSectionPlaygroundScreen(onBack: () -> Unit) {
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("CollapsibleSection") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        var basicOpen by remember { mutableStateOf(true) }
+        var slotOpen by remember { mutableStateOf(true) }
+        var lightOpen by remember { mutableStateOf(false) }
+
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .verticalScroll(rememberScrollState())
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
+            CollapsibleSection(
+                    label = "Expanded",
+                    open = basicOpen,
+                    onOpenChange = { basicOpen = it },
+            ) {
+                PlaygroundCollapsibleItem(BezierIcons.Plus, "Add item")
+                PlaygroundCollapsibleItem(BezierIcons.Star, "Favorites")
+                PlaygroundCollapsibleItem(BezierIcons.Bookmark, "Bookmarks")
+            }
+
+            CollapsibleSection(
+                    label = "Label with leading & trailing",
+                    open = slotOpen,
+                    onOpenChange = { slotOpen = it },
+                    labelLeadingContent = { PlaygroundCollapsibleLabelIcon(BezierIcons.Folder) },
+                    labelTrailingContent = {
+                        IconButton(
+                                icon = BezierIcons.Plus,
+                                onClick = {},
+                                size = IconButtonSize.Xsmall,
+                                variant = IconButtonVariant.Ghost,
+                                contentDescription = "Add",
+                        )
+                    },
+            ) {
+                PlaygroundCollapsibleItem(BezierIcons.Plus, "Add item")
+                PlaygroundCollapsibleItem(BezierIcons.Star, "Favorites")
+            }
+
+            CollapsibleSection(
+                    label = "Neutral light (collapsed)",
+                    open = lightOpen,
+                    onOpenChange = { lightOpen = it },
+                    labelColor = SectionLabelColor.NeutralLight,
+            ) {
+                PlaygroundCollapsibleItem(BezierIcons.Plus, "Add item")
+                PlaygroundCollapsibleItem(BezierIcons.Star, "Favorites")
+            }
+
+            CollapsibleSection(
+                    label = "Static (onOpenChange = null)",
+                    open = true,
+                    onOpenChange = null,
+            ) {
+                PlaygroundCollapsibleItem(BezierIcons.Bookmark, "Not togglable")
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaygroundCollapsibleItem(
+        icon: BezierIcon,
+        label: String,
+) {
+    BaseItem(
+            modifier = Modifier.fillMaxWidth(),
+            label = label,
+            size = BaseItemSize.Medium,
+            leadingContent = {
+                Icon(
+                        modifier = Modifier.fillMaxSize(),
+                        imageVector = icon.imageVector,
+                        tint = BezierTheme.colorsV3.iconNeutralHeavier,
+                        contentDescription = null,
+                )
+            },
+    )
+}
+
+@Composable
+private fun PlaygroundCollapsibleLabelIcon(icon: BezierIcon) {
+    Box(modifier = Modifier.size(20.dp)) {
+        Icon(
+                modifier = Modifier.fillMaxSize(),
+                imageVector = icon.imageVector,
+                tint = BezierTheme.colorsV3.iconNeutralHeavier,
+                contentDescription = null,
+        )
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -31,6 +31,7 @@ fun ComponentListScreen(
         onSelectToast: () -> Unit,
         onSelectCard: () -> Unit,
         onSelectSection: () -> Unit,
+        onSelectCollapsibleSection: () -> Unit,
         onSelectTextInput: () -> Unit,
         onSelectBanner: () -> Unit,
         onSelectBaseItem: () -> Unit,
@@ -81,6 +82,8 @@ fun ComponentListScreen(
             ComponentRow("Card", onClick = onSelectCard)
             Divider()
             ComponentRow("Section", onClick = onSelectSection)
+            Divider()
+            ComponentRow("CollapsibleSection", onClick = onSelectCollapsibleSection)
             Divider()
             ComponentRow("TextInput", onClick = onSelectTextInput)
             Divider()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -15,6 +15,7 @@ data object DividerPlaygroundKey
 data object ToastPlaygroundKey
 data object CardPlaygroundKey
 data object SectionPlaygroundKey
+data object CollapsibleSectionPlaygroundKey
 data object TextInputPlaygroundKey
 data object BannerPlaygroundKey
 data object BaseItemPlaygroundKey


### PR DESCRIPTION
## 요약

Figma SSOT([CollapsibleSection `4281:36`](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4281-36&m=dev)) 기준으로 v3 `CollapsibleSection`을 신규 구현했습니다.

정적 그룹핑용 `Section`과 달리 헤더에 chevron이 항상 표시되고, `open`으로 콘텐츠 영역을 접고 펼칩니다.

## API

```kotlin
CollapsibleSection(
    label: String,
    open: Boolean,
    onOpenChange: ((Boolean) -> Unit)?,
    modifier: Modifier = Modifier,
    labelColor: SectionLabelColor = SectionLabelColor.NeutralDark,
    labelLeadingContent: (@Composable () -> Unit)? = null,
    labelTrailingContent: (@Composable () -> Unit)? = null,
    content: @Composable () -> Unit,
)
```

- Figma variant 축이 `open` 하나뿐이라 `SectionVariant`(Solid/Card)는 노출하지 않았습니다.
- `open` / `onOpenChange`는 `Switch.kt`의 controlled 관용을 따랐습니다. `onOpenChange = null`이면 토글 불가.

## Figma 매핑

| 항목 | 값 |
|---|---|
| 헤더 | min-height 32, horizontal padding 10, radius 8, gap 4 |
| centerContent | gap 8, min-height 24 |
| 슬롯 | leading 20×20, chevron 16×16, trailing height 20 |
| Typography | `BezierTypo.TextMedium` + `BezierWeight.Bold` (`Typography/text/medium-bold`) |
| neutral-dark | text `textNeutral` / chevron `iconNeutralHeavier` |
| neutral-light | text `textNeutralLighter` / chevron `iconNeutral` |
| chevron | open=true `ChevronSmallDown` / open=false `ChevronSmallRight` |

text와 chevron이 raw hex는 같지만 Figma에서 별개 변수라 토큰도 분리해 매핑했습니다.

## 변경 사항

| 파일 | 내용 |
|---|---|
| `v3/component/CollapsibleSection.kt` | 신규 |
| `v3/component/Section.kt` | `SectionLabelColor.textColor()` `private` → `internal` (색 매핑 재사용) |
| `playground/CollapsibleSectionPlaygroundScreen.kt` | 신규 |
| `playground/NavKeys.kt`, `ComponentListScreen.kt`, `MainActivity.kt` | 플레이그라운드 등록 |

## 확인 필요 — 토글 히트 영역

**Figma에 토글 트리거의 히트 영역이 정의되어 있지 않습니다.** `CollapsibleSection` / `Internal/CollapsibleSectionLabel` 두 description 모두 히트 영역·탭 타겟을 언급하지 않고 프로토타입 정보도 없습니다.

동작하는 컴포넌트가 필요해 **헤더 Row 전체를 clickable**로 두었습니다. `labelTrailingContent`에 IconButton을 넣는 경우(Figma의 trailingContent 기본값이 IconButton) 자식이 클릭을 먼저 소비해 헤더 토글은 동작하지 않습니다. chevron만 탭 타겟으로 좁힐지 헤더 전체를 유지할지 디자이너 확인이 필요합니다.

## 테스트

- `./gradlew :sample:assembleDebug` 성공
- 라이트/다크 `@Preview` 2종, 플레이그라운드 4케이스(기본 / 슬롯 / neutral-light collapsed / 토글 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
