### PR TITLE
v3 DropdownMenu 컴포넌트 구현

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/DropdownMenu.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/DropdownMenu.kt
@@ -1,0 +1,509 @@
+package io.channel.bezier.v3.component
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntRect
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import io.channel.bezier.BezierIcon
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.Plus
+import io.channel.bezier.icon.Trash
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.typography.BezierWeight
+
+@Composable
+fun DropdownMenu(
+        expanded: Boolean,
+        onDismissRequest: () -> Unit,
+        modifier: Modifier = Modifier,
+        trigger: @Composable () -> Unit,
+        content: @Composable ColumnScope.() -> Unit,
+) {
+    var anchorBounds by remember { mutableStateOf(IntRect.Zero) }
+
+    Box(
+            modifier = modifier.onGloballyPositioned {
+                anchorBounds = it.boundsInWindow().roundToIntRect()
+            },
+    ) {
+        trigger()
+
+        if (expanded) {
+            val density = LocalDensity.current
+            val layoutDirection = LocalLayoutDirection.current
+            val containerSize = LocalWindowInfo.current.containerSize
+            val safeDrawing = WindowInsets.safeDrawing
+            val topInset = safeDrawing.getTop(density)
+            val bottomInset = safeDrawing.getBottom(density)
+            val leftInset = safeDrawing.getLeft(density, layoutDirection)
+            val rightInset = safeDrawing.getRight(density, layoutDirection)
+
+            val positionProvider = remember(
+                    density,
+                    containerSize,
+                    topInset,
+                    bottomInset,
+                    leftInset,
+                    rightInset,
+            ) {
+                DropdownMenuPositionProvider(
+                        density = density,
+                        containerSize = containerSize,
+                        topInset = topInset,
+                        bottomInset = bottomInset,
+                        leftInset = leftInset,
+                        rightInset = rightInset,
+                )
+            }
+            val maxHeight = remember(anchorBounds, containerSize, topInset, bottomInset, density) {
+                with(density) {
+                    val spaceBelow = containerSize.height - bottomInset - anchorBounds.bottom
+                    val spaceAbove = anchorBounds.top - topInset
+                    val available = maxOf(spaceBelow, spaceAbove)
+                    (available.toDp() - OverlayTriggerGap - OverlayScreenMargin).coerceAtLeast(0.dp)
+                }
+            }
+
+            Popup(
+                    popupPositionProvider = positionProvider,
+                    onDismissRequest = onDismissRequest,
+                    properties = PopupProperties(focusable = true),
+            ) {
+                DropdownMenuOverlay(
+                        maxHeight = maxHeight,
+                        content = content,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DropdownMenuOverlay(
+        maxHeight: Dp,
+        modifier: Modifier = Modifier,
+        content: @Composable ColumnScope.() -> Unit,
+) {
+    val elevationColor = BezierTheme.colorsV3.elevationLarge
+    val shadow = remember(elevationColor) {
+        Shadow(
+                radius = OverlayShadowRadius,
+                color = elevationColor,
+                spread = 0.dp,
+                offset = DpOffset(0.dp, OverlayShadowOffsetY),
+        )
+    }
+
+    Column(
+            modifier = modifier
+                    .widthIn(min = OverlayMinWidth, max = OverlayMaxWidth)
+                    .width(IntrinsicSize.Max)
+                    .heightIn(max = maxHeight)
+                    .dropShadow(
+                            shape = OverlayShape,
+                            shadow = shadow,
+                    )
+                    .clip(OverlayShape)
+                    .background(BezierTheme.colorsV3.surfaceHighest)
+                    .verticalScroll(rememberScrollState())
+                    .padding(OverlayPadding),
+            content = content,
+    )
+}
+
+@Composable
+fun DropdownMenuGroup(
+        modifier: Modifier = Modifier,
+        label: String? = null,
+        showDivider: Boolean = false,
+        content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (label != null) {
+            Row(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = GroupLabelMinHeight)
+                            .padding(horizontal = GroupLabelHorizontalPadding),
+                    verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BezierText(
+                        text = label,
+                        typo = BezierTypo.TextMedium,
+                        weight = BezierWeight.Bold,
+                        color = BezierTheme.colorsV3.textNeutralLighter,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                )
+            }
+        }
+
+        content()
+
+        if (showDivider) {
+            Divider()
+        }
+    }
+}
+
+@Composable
+fun DropdownMenuItem(
+        label: String,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        variant: DropdownMenuItemVariant = DropdownMenuItemVariant.Neutral,
+        enabled: Boolean = true,
+        description: String? = null,
+        leadingIcon: BezierIcon? = null,
+        leadingContent: (@Composable () -> Unit)? = null,
+        centerSlot: (@Composable () -> Unit)? = null,
+        trailingContent: (@Composable () -> Unit)? = null,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val hasLeading = leadingContent != null || leadingIcon != null
+    val isPressed = interactionSource.collectIsPressedAsState()
+    val pressedColor = BezierTheme.colorsV3.fillNeutralLighter
+
+    Row(
+            modifier = modifier
+                    .fillMaxWidth()
+                    .heightIn(min = ItemMinHeight)
+                    .then(
+                            if (enabled) Modifier
+                            else Modifier.graphicsLayer(alpha = ItemDisabledAlpha),
+                    )
+                    .clip(ItemShape)
+                    .drawBehind {
+                        if (isPressed.value) {
+                            drawRoundRect(
+                                    color = pressedColor,
+                                    cornerRadius = CornerRadius(ItemCornerRadius.toPx()),
+                            )
+                        }
+                    }
+                    .clickable(
+                            interactionSource = interactionSource,
+                            indication = null,
+                            enabled = enabled,
+                            onClick = onClick,
+                    )
+                    .padding(
+                            horizontal = ItemHorizontalPadding,
+                            vertical = ItemVerticalPadding,
+                    ),
+            horizontalArrangement = Arrangement.spacedBy(ItemGap),
+            verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(if (hasLeading) ItemGap else 0.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (leadingContent != null) {
+                    Box(modifier = Modifier.size(ItemLeadingContentSize)) {
+                        leadingContent()
+                    }
+                } else if (leadingIcon != null) {
+                    Icon(
+                            modifier = Modifier.size(ItemLeadingContentSize),
+                            imageVector = leadingIcon.imageVector,
+                            tint = variant.iconColor(),
+                            contentDescription = null,
+                    )
+                }
+
+                Row(
+                        modifier = Modifier.weight(1f),
+                        horizontalArrangement = Arrangement.spacedBy(ItemLabelRowGap),
+                        verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    BezierText(
+                            text = label,
+                            typo = BezierTypo.TextXLarge,
+                            color = variant.textColor(),
+                            overflow = TextOverflow.Ellipsis,
+                            maxLines = 1,
+                            modifier = Modifier.weight(1f, fill = false),
+                    )
+
+                    if (centerSlot != null) {
+                        centerSlot()
+                    }
+                }
+            }
+
+            if (description != null) {
+                BezierText(
+                        text = description,
+                        typo = BezierTypo.CaptionMedium,
+                        color = BezierTheme.colorsV3.textNeutralLighter,
+                        modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = if (hasLeading) ItemDescriptionIndent else 0.dp),
+                )
+            }
+        }
+
+        if (trailingContent != null) {
+            trailingContent()
+        }
+    }
+}
+
+enum class DropdownMenuItemVariant {
+    Neutral,
+    Destructive,
+}
+
+@Composable
+private fun DropdownMenuItemVariant.textColor(): Color = when (this) {
+    DropdownMenuItemVariant.Neutral -> BezierTheme.colorsV3.textNeutral
+    DropdownMenuItemVariant.Destructive -> BezierTheme.colorsV3.textAccentRed
+}
+
+@Composable
+private fun DropdownMenuItemVariant.iconColor(): Color = when (this) {
+    DropdownMenuItemVariant.Neutral -> BezierTheme.colorsV3.iconNeutralHeavy
+    DropdownMenuItemVariant.Destructive -> BezierTheme.colorsV3.iconAccentRed
+}
+
+private class DropdownMenuPositionProvider(
+        private val density: Density,
+        private val containerSize: IntSize,
+        private val topInset: Int,
+        private val bottomInset: Int,
+        private val leftInset: Int,
+        private val rightInset: Int,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+            anchorBounds: IntRect,
+            windowSize: IntSize,
+            layoutDirection: LayoutDirection,
+            popupContentSize: IntSize,
+    ): IntOffset {
+        val gap = with(density) { OverlayTriggerGap.roundToPx() }
+        val margin = with(density) { OverlayScreenMargin.roundToPx() }
+
+        val leftLimit = leftInset + margin
+        val rightLimit = containerSize.width - rightInset - margin
+        val startX = if (layoutDirection == LayoutDirection.Ltr) {
+            anchorBounds.left
+        } else {
+            anchorBounds.right - popupContentSize.width
+        }
+        val maxX = (rightLimit - popupContentSize.width).coerceAtLeast(leftLimit)
+        val x = startX.coerceIn(leftLimit, maxX)
+
+        val topLimit = topInset + margin
+        val bottomLimit = containerSize.height - bottomInset - margin
+        val below = anchorBounds.bottom + gap
+        val above = anchorBounds.top - gap - popupContentSize.height
+        val fitsBelow = below + popupContentSize.height <= bottomLimit
+        val maxY = (bottomLimit - popupContentSize.height).coerceAtLeast(topLimit)
+        val y = (if (fitsBelow || above < topLimit) below else above).coerceIn(topLimit, maxY)
+
+        return IntOffset(x, y)
+    }
+}
+
+private val OverlayMinWidth: Dp = 160.dp
+private val OverlayMaxWidth: Dp = 280.dp
+private val OverlayPadding: Dp = 10.dp
+private val OverlayCornerRadius: Dp = 32.dp
+private val OverlayShadowRadius: Dp = 20.dp
+private val OverlayShadowOffsetY: Dp = 4.dp
+private val OverlayTriggerGap: Dp = 8.dp
+private val OverlayScreenMargin: Dp = 16.dp
+private val OverlayShape = RoundedCornerShape(OverlayCornerRadius)
+
+private val GroupLabelMinHeight: Dp = 32.dp
+private val GroupLabelHorizontalPadding: Dp = 10.dp
+
+private val ItemMinHeight: Dp = 40.dp
+private val ItemHorizontalPadding: Dp = 10.dp
+private val ItemVerticalPadding: Dp = 6.dp
+private val ItemGap: Dp = 10.dp
+private val ItemLabelRowGap: Dp = 4.dp
+private val ItemLeadingContentSize: Dp = 24.dp
+private val ItemDescriptionIndent: Dp = 34.dp
+private val ItemCornerRadius: Dp = 16.dp
+private val ItemDisabledAlpha: Float = 0.4f
+private val ItemShape = RoundedCornerShape(ItemCornerRadius)
+
+private val PreviewOverlayMaxHeight: Dp = 400.dp
+
+@Composable
+private fun DropdownMenuPreviewContent() {
+    BezierTheme {
+        Column(
+                modifier = Modifier
+                        .fillMaxSize()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            DropdownMenuOverlay(maxHeight = PreviewOverlayMaxHeight) {
+                DropdownMenuItem(label = "Edit", onClick = {})
+                DropdownMenuItem(
+                        label = "Pressed",
+                        onClick = {},
+                        interactionSource = pressedInteractionSource(),
+                )
+                DropdownMenuItem(label = "Disabled", onClick = {}, enabled = false)
+            }
+
+            DropdownMenuOverlay(maxHeight = PreviewOverlayMaxHeight) {
+                DropdownMenuGroup(label = "Group Label", showDivider = true) {
+                    DropdownMenuItem(
+                            label = "With icon",
+                            onClick = {},
+                            leadingIcon = BezierIcons.Plus,
+                    )
+                    DropdownMenuItem(
+                            label = "With description",
+                            description = "Description text",
+                            onClick = {},
+                            leadingIcon = BezierIcons.Plus,
+                            centerSlot = { PreviewCenterSlot() },
+                            trailingContent = { PreviewTrailingContent() },
+                    )
+                    DropdownMenuItem(
+                            label = "Custom leading",
+                            onClick = {},
+                            leadingContent = { PreviewLeadingContent() },
+                    )
+                }
+
+                DropdownMenuGroup {
+                    DropdownMenuItem(
+                            label = "Delete",
+                            onClick = {},
+                            variant = DropdownMenuItemVariant.Destructive,
+                            leadingIcon = BezierIcons.Trash,
+                    )
+                    DropdownMenuItem(
+                            label = "Delete pressed",
+                            onClick = {},
+                            variant = DropdownMenuItemVariant.Destructive,
+                            leadingIcon = BezierIcons.Trash,
+                            interactionSource = pressedInteractionSource(),
+                    )
+                    DropdownMenuItem(
+                            label = "Delete disabled",
+                            onClick = {},
+                            enabled = false,
+                            variant = DropdownMenuItemVariant.Destructive,
+                            leadingIcon = BezierIcons.Trash,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun pressedInteractionSource(): MutableInteractionSource {
+    val source = remember { MutableInteractionSource() }
+    LaunchedEffect(source) {
+        source.emit(PressInteraction.Press(Offset.Zero))
+    }
+    return source
+}
+
+@Composable
+private fun PreviewLeadingContent() {
+    Box(
+            modifier = Modifier
+                    .fillMaxSize()
+                    .clip(CircleShape)
+                    .background(BezierTheme.colorsV3.fillNeutral),
+    )
+}
+
+@Composable
+private fun PreviewCenterSlot() {
+    Box(
+            modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(BezierTheme.colorsV3.fillNeutralHeavier),
+    )
+}
+
+@Composable
+private fun PreviewTrailingContent() {
+    Box(
+            modifier = Modifier
+                    .size(24.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(BezierTheme.colorsV3.fillNeutral),
+    )
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+private fun DropdownMenuPreview() = DropdownMenuPreviewContent()
+
+@Preview(showBackground = true, widthDp = 360, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun DropdownMenuDarkPreview() = DropdownMenuPreviewContent()

--- a/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/MainActivity.kt
@@ -39,6 +39,8 @@ import io.channel.bezier.compose.sample.playground.ComponentListKey
 import io.channel.bezier.compose.sample.playground.ComponentListScreen
 import io.channel.bezier.compose.sample.playground.DividerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.DividerPlaygroundScreen
+import io.channel.bezier.compose.sample.playground.DropdownMenuPlaygroundKey
+import io.channel.bezier.compose.sample.playground.DropdownMenuPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.FloatingBannerPlaygroundKey
 import io.channel.bezier.compose.sample.playground.FloatingBannerPlaygroundScreen
 import io.channel.bezier.compose.sample.playground.IconButtonPlaygroundKey
@@ -113,6 +115,7 @@ private fun PlaygroundApp() {
                                     onSelectTextArea = { backStack.add(TextAreaPlaygroundKey) },
                                     onSelectModal = { backStack.add(ModalPlaygroundKey) },
                                     onSelectConfirmModal = { backStack.add(ConfirmModalPlaygroundKey) },
+                                    onSelectDropdownMenu = { backStack.add(DropdownMenuPlaygroundKey) },
                             )
                         }
                         entry<ButtonPlaygroundKey> {
@@ -183,6 +186,9 @@ private fun PlaygroundApp() {
                         }
                         entry<ConfirmModalPlaygroundKey> {
                             ConfirmModalPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
+                        }
+                        entry<DropdownMenuPlaygroundKey> {
+                            DropdownMenuPlaygroundScreen(onBack = { backStack.removeLastOrNull() })
                         }
                     },
             )

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/ComponentListScreen.kt
@@ -40,6 +40,7 @@ fun ComponentListScreen(
         onSelectTextArea: () -> Unit,
         onSelectModal: () -> Unit,
         onSelectConfirmModal: () -> Unit,
+        onSelectDropdownMenu: () -> Unit,
 ) {
     Scaffold(
             topBar = {
@@ -99,6 +100,8 @@ fun ComponentListScreen(
             ComponentRow("Modal", onClick = onSelectModal)
             Divider()
             ComponentRow("ConfirmModal", onClick = onSelectConfirmModal)
+            Divider()
+            ComponentRow("DropdownMenu", onClick = onSelectDropdownMenu)
             Divider()
         }
     }

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/DropdownMenuPlaygroundScreen.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/DropdownMenuPlaygroundScreen.kt
@@ -1,0 +1,264 @@
+package io.channel.bezier.compose.sample.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import io.channel.bezier.BezierIcons
+import io.channel.bezier.BezierTheme
+import io.channel.bezier.component.BezierText
+import io.channel.bezier.icon.ArrowLeft
+import io.channel.bezier.icon.Bookmark
+import io.channel.bezier.icon.Edit
+import io.channel.bezier.icon.LinkCopy
+import io.channel.bezier.icon.More
+import io.channel.bezier.icon.Star
+import io.channel.bezier.icon.Trash
+import io.channel.bezier.typography.BezierTypo
+import io.channel.bezier.v3.component.Badge
+import io.channel.bezier.v3.component.DropdownMenu
+import io.channel.bezier.v3.component.DropdownMenuGroup
+import io.channel.bezier.v3.component.DropdownMenuItem
+import io.channel.bezier.v3.component.DropdownMenuItemVariant
+import io.channel.bezier.v3.component.IconButton
+import io.channel.bezier.v3.component.IconButtonSize
+import io.channel.bezier.v3.component.IconButtonVariant
+
+@Composable
+fun DropdownMenuPlaygroundScreen(onBack: () -> Unit) {
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("DropdownMenu") },
+                        navigationIcon = {
+                            IconButton(
+                                    icon = BezierIcons.ArrowLeft,
+                                    onClick = onBack,
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "Back",
+                            )
+                        },
+                )
+            },
+    ) { padding ->
+        Column(
+                modifier = Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .background(BezierTheme.colorsV3.surfaceLow)
+                        .verticalScroll(rememberScrollState())
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
+            PlaygroundMenuRow(title = "Basic") { expanded, onExpandedChange ->
+                DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { onExpandedChange(false) },
+                        trigger = {
+                            IconButton(
+                                    icon = BezierIcons.More,
+                                    onClick = { onExpandedChange(true) },
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "More",
+                            )
+                        },
+                ) {
+                    DropdownMenuItem(label = "Edit", onClick = { onExpandedChange(false) })
+                    DropdownMenuItem(label = "Duplicate", onClick = { onExpandedChange(false) })
+                    DropdownMenuItem(label = "Delete", onClick = { onExpandedChange(false) })
+                }
+            }
+
+            PlaygroundMenuRow(title = "Leading icon + destructive") { expanded, onExpandedChange ->
+                DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { onExpandedChange(false) },
+                        trigger = {
+                            IconButton(
+                                    icon = BezierIcons.More,
+                                    onClick = { onExpandedChange(true) },
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Filled,
+                                    contentDescription = "More",
+                            )
+                        },
+                ) {
+                    DropdownMenuItem(
+                            label = "Edit",
+                            onClick = { onExpandedChange(false) },
+                            leadingIcon = BezierIcons.Edit,
+                    )
+                    DropdownMenuItem(
+                            label = "Duplicate",
+                            onClick = { onExpandedChange(false) },
+                            leadingIcon = BezierIcons.LinkCopy,
+                    )
+                    DropdownMenuItem(
+                            label = "Delete",
+                            onClick = { onExpandedChange(false) },
+                            variant = DropdownMenuItemVariant.Destructive,
+                            leadingIcon = BezierIcons.Trash,
+                    )
+                }
+            }
+
+            PlaygroundMenuRow(title = "Groups + label + divider") { expanded, onExpandedChange ->
+                DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { onExpandedChange(false) },
+                        trigger = {
+                            IconButton(
+                                    icon = BezierIcons.More,
+                                    onClick = { onExpandedChange(true) },
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "More",
+                            )
+                        },
+                ) {
+                    DropdownMenuGroup(label = "Actions", showDivider = true) {
+                        DropdownMenuItem(
+                                label = "Star",
+                                onClick = { onExpandedChange(false) },
+                                leadingIcon = BezierIcons.Star,
+                                centerSlot = { Badge(label = "New") },
+                        )
+                        DropdownMenuItem(
+                                label = "Bookmark",
+                                onClick = { onExpandedChange(false) },
+                                leadingIcon = BezierIcons.Bookmark,
+                                trailingContent = {
+                                    BezierText(
+                                            text = "12",
+                                            typo = BezierTypo.TextMedium,
+                                            color = BezierTheme.colorsV3.textNeutralLighter,
+                                    )
+                                },
+                        )
+                    }
+
+                    DropdownMenuGroup(label = "Danger") {
+                        DropdownMenuItem(
+                                label = "Delete",
+                                description = "This cannot be undone",
+                                onClick = { onExpandedChange(false) },
+                                variant = DropdownMenuItemVariant.Destructive,
+                                leadingIcon = BezierIcons.Trash,
+                        )
+                    }
+                }
+            }
+
+            PlaygroundMenuRow(title = "Custom leading + disabled") { expanded, onExpandedChange ->
+                DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { onExpandedChange(false) },
+                        trigger = {
+                            IconButton(
+                                    icon = BezierIcons.More,
+                                    onClick = { onExpandedChange(true) },
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "More",
+                            )
+                        },
+                ) {
+                    DropdownMenuItem(
+                            label = "Custom leading",
+                            onClick = { onExpandedChange(false) },
+                            leadingContent = {
+                                Box(
+                                        modifier = Modifier
+                                                .fillMaxSize()
+                                                .clip(CircleShape)
+                                                .background(BezierTheme.colorsV3.fillNeutral),
+                                )
+                            },
+                    )
+                    DropdownMenuItem(
+                            label = "Disabled",
+                            onClick = { onExpandedChange(false) },
+                            enabled = false,
+                            leadingIcon = BezierIcons.Edit,
+                    )
+                    DropdownMenuItem(
+                            label = "Disabled destructive",
+                            onClick = { onExpandedChange(false) },
+                            enabled = false,
+                            variant = DropdownMenuItemVariant.Destructive,
+                            leadingIcon = BezierIcons.Trash,
+                    )
+                }
+            }
+
+            PlaygroundMenuRow(title = "Long list (scroll)") { expanded, onExpandedChange ->
+                DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { onExpandedChange(false) },
+                        trigger = {
+                            IconButton(
+                                    icon = BezierIcons.More,
+                                    onClick = { onExpandedChange(true) },
+                                    size = IconButtonSize.Medium,
+                                    variant = IconButtonVariant.Ghost,
+                                    contentDescription = "More",
+                            )
+                        },
+                ) {
+                    repeat(20) { index ->
+                        DropdownMenuItem(
+                                label = "Item ${index + 1}",
+                                onClick = { onExpandedChange(false) },
+                        )
+                    }
+                }
+            }
+
+            Box(modifier = Modifier.size(240.dp))
+        }
+    }
+}
+
+@Composable
+private fun PlaygroundMenuRow(
+        title: String,
+        menu: @Composable (expanded: Boolean, onExpandedChange: (Boolean) -> Unit) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BezierText(
+                text = title,
+                typo = BezierTypo.TextMedium,
+                color = BezierTheme.colorsV3.textNeutral,
+        )
+
+        menu(expanded) { expanded = it }
+    }
+}

--- a/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
+++ b/sample/src/main/java/io/channel/bezier/compose/sample/playground/NavKeys.kt
@@ -24,3 +24,4 @@ data object ItemsPlaygroundKey
 data object TextAreaPlaygroundKey
 data object ModalPlaygroundKey
 data object ConfirmModalPlaygroundKey
+data object DropdownMenuPlaygroundKey


### PR DESCRIPTION
## 요약

Figma [DropdownMenu(2070:19)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2070-19&m=dev) 기반 트리거 + 오버레이 메뉴를 추가합니다. 오버레이는 `Popup`으로 띄우고 내용은 `DropdownMenuGroup` / `DropdownMenuItem` 슬롯이 조립합니다.

## API

```kotlin
DropdownMenu(
    expanded = expanded,
    onDismissRequest = { expanded = false },
    trigger = { IconButton(icon = BezierIcons.More, onClick = { expanded = true }) },
) {
    DropdownMenuGroup(label = "Actions", showDivider = true) {
        DropdownMenuItem(label = "Edit", onClick = {}, leadingIcon = BezierIcons.Edit)
    }
    DropdownMenuItem(
        label = "Delete",
        onClick = {},
        variant = DropdownMenuItemVariant.Destructive,
        leadingIcon = BezierIcons.Trash,
    )
}
```

## 구현 내용

**오버레이**
- 배경 `surfaceHighest`, radius 32, padding 10, 폭 HUG (min 160 / max 280)
- `Elevation/Mobile/3` — dropShadow radius 20, offset (0, 4), `elevationLarge`
- 배치는 bottom-start, 트리거와 8 간격, 아래 공간이 부족하면 위로 flip
- 화면 가장자리 마진 16, `WindowInsets.safeDrawing` 인셋 기준으로 max-height 계산 후 내부 스크롤

**DropdownMenuGroup**
- `label` (TextMedium Bold / `textNeutralLighter`), `showDivider` 옵션
- divider는 기존 v3 `Divider`를 그대로 사용 (indent 6 / 두께 1 / `borderNeutral`)

**DropdownMenuItem**
- min-height 40, padding 10/6, radius 16, gap 10
- `variant` neutral / destructive — label과 icon이 서로 다른 토큰을 씁니다
  - neutral: `textNeutral`(0.85) + `iconNeutralHeavy`(0.6)
  - destructive: `textAccentRed` + `iconAccentRed`
- pressed는 배경 `fillNeutralLighter`만 바뀌고 전경색은 default와 동일
- disabled는 색 교체 없이 alpha 0.4 + 클릭 차단
- `leadingIcon` / `leadingContent` / `centerSlot` / `trailingContent` / `description` 슬롯

**최적화**
- pressed 상태를 `drawBehind`에서 읽어 재구성 없이 재드로우만 발생시킵니다
- `enabled`일 때는 `graphicsLayer`를 붙이지 않아 불필요한 레이어 생성을 피합니다

## Figma가 정하지 않아 구현에서 결정한 것

| 항목 | 결정 | 근거 |
|---|---|---|
| 트리거↔오버레이 간격 | 8 | Figma 레이어는 gap 4지만 overlay component description이 "트리거와 8px 간격"으로 규정 |
| 오버레이 표시 방식 | `androidx.compose.ui.window.Popup` | description의 "backdrop 없음 · 외부 탭 시 닫힘"을 만족 |
| `leadingType` 표현 | `leadingIcon` + `leadingContent` 두 파라미터 | Figma의 3값 enum(none/icon/custom)을 Compose slot 관용으로 옮김. icon은 variant별 tint를 컴포넌트가 책임져야 해서 분리 |
| label 넘침 | `TextOverflow.Ellipsis` + `maxLines = 1` | Figma는 말줄임 여부 미규정. `BaseItem` 선례를 따름 |
| GroupLabel radius 8 | 미적용 | 배경·보더가 없어 시각 결과가 없고 레이어 비용만 발생 |

## 확인

- `:bezier:compileDebugKotlin`, `:sample:compileDebugKotlin` 통과
- Preview: light / dark, default·pressed·disabled × neutral·destructive
- 플레이그라운드 5개 시나리오 (basic / leading icon + destructive / group + divider / custom leading + disabled / 20개 스크롤)

## 남은 항목

비-edge-to-edge 호스트 앱(`decorFitsSystemWindows = true`)에서는 `WindowInsets.safeDrawing`이 0으로 읽혀 메뉴가 시스템 바 영역까지 확장될 수 있습니다. 샘플 앱은 `enableEdgeToEdge()`를 쓰므로 현재 구성에서는 발현하지 않습니다. 라이브러리가 비-edge-to-edge 호스트를 지원 범위에 넣을지는 별도 결정이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
