### PR TITLE
인터랙션 컴포넌트 마커 키 개명 (BezierComponentKey → InteractionComponentKey)

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/component/ListItemContainer.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/ListItemContainer.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.semantics.semantics
 import io.channel.bezier.compose.R
-import io.channel.bezier.interaction.bezierComponent
+import io.channel.bezier.interaction.interactionComponent
 import kotlin.math.max
 
 @Composable
@@ -55,7 +55,7 @@ fun ListItemContainer(
 ) {
     Column(
             modifier = modifier
-                    .semantics { bezierComponent = "ListItemContainer" }
+                    .semantics { interactionComponent = "ListItemContainer" }
                     .fillMaxWidth()
                     .heightIn(min = size.minHeight)
                     .padding(start = 6.dp)

--- a/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
+++ b/bezier/src/main/java/io/channel/bezier/component/SectionLabel.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.semantics.semantics
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.compose.R
-import io.channel.bezier.interaction.bezierComponent
+import io.channel.bezier.interaction.interactionComponent
 
 @Composable
 fun SectionLabel(
@@ -35,7 +35,7 @@ fun SectionLabel(
 ) {
     Row(
             modifier = modifier
-                    .semantics { bezierComponent = "SectionLabel" }
+                    .semantics { interactionComponent = "SectionLabel" }
                     .sizeIn(minHeight = 32.dp),
             verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
+++ b/bezier/src/main/java/io/channel/bezier/interaction/BezierComponentInteraction.kt
@@ -13,9 +13,9 @@ object BezierComponentInteraction {
     }
 }
 
-val BezierComponentKey = SemanticsPropertyKey<String>(
-        name = "BezierComponent",
+val InteractionComponentKey = SemanticsPropertyKey<String>(
+        name = "InteractionComponent",
         mergePolicy = { parent, child -> parent ?: child },
 )
 
-var SemanticsPropertyReceiver.bezierComponent by BezierComponentKey
+var SemanticsPropertyReceiver.interactionComponent by InteractionComponentKey

--- a/bezier/src/main/java/io/channel/bezier/v3/component/BaseItem.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/BaseItem.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
-import io.channel.bezier.interaction.bezierComponent
+import io.channel.bezier.interaction.interactionComponent
 import io.channel.bezier.typography.BezierTypo
 
 @Composable
@@ -40,7 +40,7 @@ fun BaseItem(
 ) {
     Row(
             modifier = modifier
-                    .semantics { bezierComponent = "BaseItem" }
+                    .semantics { interactionComponent = "BaseItem" }
                     .clip(RoundedCornerShape(BaseItemCornerRadius))
                     .heightIn(min = size.minHeight)
                     .padding(


### PR DESCRIPTION
## 무엇

`interaction` 패키지의 컴포넌트 종류 마커 키를 실체에 맞는 중립 이름으로 개명한다.

- `BezierComponentKey` → `InteractionComponentKey`
- `SemanticsPropertyReceiver.bezierComponent` → `interactionComponent`
- 시맨틱스 이름 문자열 `"BezierComponent"` → `"InteractionComponent"`
- 내부 마커 사용처 3곳(ListItemContainer·SectionLabel·BaseItem) 동반 수정

## 왜

이 마커는 "클릭 분류를 위한 컴포넌트 종류 이름표"라는 일반 계약이고, 호스트 앱이 자기 공용 컴포넌트(GNB 버튼 등)에도 같은 키를 쓴다. 디자인 시스템 컴포넌트가 아닌 곳에서 `bezierComponent` 라는 이름은 실체와 어긋난다. `BezierComponentInteraction` 계약과 같은 패키지의 쌍(`interactionComponent`)이 되도록 정정한다.

## 호환성

- 3.3.0 소비처는 현재 desk Android 앱뿐이며, 릴리즈 후 앱이 함께 개명 반영 예정(합의됨)
- 동작 변화 없음 — 이름만 변경. `:bezier:compileDebugKotlin`·`:sample:compileDebugKotlin` 그린


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * UI 구성 요소의 접근성 의미론 속성 명칭을 일관된 `interactionComponent`로 통합했습니다.
  * 기존 컴포넌트 식별자와 동작은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->