### PR TITLE
v3 Section 헤더에 인터랙션 컴포넌트 마커 부착

### DIFF
--- a/bezier/src/main/java/io/channel/bezier/v3/component/Section.kt
+++ b/bezier/src/main/java/io/channel/bezier/v3/component/Section.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -26,6 +27,7 @@ import io.channel.bezier.BezierIcons
 import io.channel.bezier.BezierTheme
 import io.channel.bezier.component.BezierText
 import io.channel.bezier.icon.ChevronSmallRight
+import io.channel.bezier.interaction.interactionComponent
 import io.channel.bezier.icon.Folder
 import io.channel.bezier.icon.Plus
 import io.channel.bezier.typography.BezierTypo
@@ -77,6 +79,7 @@ private fun SectionLabel(
 ) {
     Row(
             modifier = modifier
+                    .semantics { interactionComponent = "Section" }
                     .fillMaxWidth()
                     .heightIn(min = SectionLabelMinHeight)
                     .padding(horizontal = SectionLabelHorizontalPadding),


### PR DESCRIPTION
## 무엇

v3 `Section` 의 헤더 행에 `interactionComponent = "Section"` 시맨틱스 마커를 심습니다. 클릭을 호출부가 소유하는 컴포넌트의 마커 방식(v1 `SectionLabel` / `ListItemContainer` / v3 `BaseItem`)과 동일합니다.

## 왜

앱 자동 트래킹에서 v3 섹션 헤더 클릭이 마커가 없어 `Unknown` 으로 빠집니다. 마커가 있으면 호출부 clickable 의 병합 시맨틱스로 상승해 `SectionLabel`(V3) 로 분류됩니다. 실명 "Section" → 스키마 값 변환은 앱 매핑표가 담당합니다.

## 확인

- `:bezier:compileDebugKotlin` 그린
- 동작 변화 없음(시맨틱스 키 추가만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 섹션 레이블에 접근성 및 UI 상호작용 정보가 추가되어, 화면 요소가 ‘Section’으로 올바르게 인식됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->